### PR TITLE
Add first rough pass at fixing #28

### DIFF
--- a/bin/env-activate
+++ b/bin/env-activate
@@ -36,7 +36,18 @@ get_dirname() {
 }
 source "$(get_dirname ${_ABS_SCRIPT_LOCATION})/_conda-functions"
 
-if "$_THIS_DIR/conda" ..checkenv "$@"; then
+if [[ "$@" == "" ]]; then
+    _POSSIBLE_ENV_NAME="$(conda env info --only=name)"
+    if [[ "${_POSSIBLE_ENV_NAME}" != "" ]]; then
+        _ENV_NAME=$_POSSIBLE_ENV_NAME
+    else
+        _ENV_NAME=""
+    fi
+else
+    _ENV_NAME="$@"
+fi
+
+if "$_THIS_DIR/conda" ..checkenv $_ENV_NAME; then
     # Ensure we deactivate any scripts from the old env
     run_scripts "deactivate"
 
@@ -52,14 +63,14 @@ else
     return 1
 fi
 
-_NEW_PATH=$("$_THIS_DIR/conda" ..activate "$@")
+_NEW_PATH=$("$_THIS_DIR/conda" ..activate ${_ENV_NAME})
 if (( $? == 0 )); then
     export PATH=$_NEW_PATH
     # If the string contains / it's a path
-    if [[ "$@" == */* ]]; then
-        export CONDA_DEFAULT_ENV=$(get_abs_filename "$@")
+    if [[ "${_ENV_NAME}" == */* ]]; then
+        export CONDA_DEFAULT_ENV=$(get_abs_filename ${_ENV_NAME})
     else
-        export CONDA_DEFAULT_ENV="$@"
+        export CONDA_DEFAULT_ENV=$_ENV_NAME
     fi
 
     if (( $("$_THIS_DIR/conda" ..changeps1) ));  then

--- a/conda_env/cli/main.py
+++ b/conda_env/cli/main.py
@@ -8,6 +8,7 @@ from . import main_create
 from . import main_export
 from . import main_list
 from . import main_remove
+from . import main_info
 
 
 def create_parser():
@@ -18,6 +19,7 @@ def create_parser():
     main_export.configure_parser(sub_parsers)
     main_list.configure_parser(sub_parsers)
     main_remove.configure_parser(sub_parsers)
+    main_info.configure_parser(sub_parsers)
     return p
 
 

--- a/conda_env/cli/main_info.py
+++ b/conda_env/cli/main_info.py
@@ -1,0 +1,50 @@
+import os
+import yaml
+
+
+# TODO Refactor
+def configure_parser(sub_parsers):
+    p = sub_parsers.add_parser(
+        'info',
+    )
+    p.add_argument(
+        '--only',
+        action='store',
+        help='only display these names (comma-separated)',
+        required=False
+    )
+    p.add_argument(
+        '--quiet',
+        action='store_true',
+        help='reduce output',
+        default=False
+    )
+    p.add_argument(
+        '-f', '--file',
+        action='store',
+        help='environment definition (default: environment.yml)',
+        default='environment.yml',
+    )
+    p.set_defaults(func=execute)
+    return p
+
+
+def execute(args, parser):
+    # TODO create a Python API for interacting with "environments"
+    if not os.path.exists(args.file):
+        if getattr(args, 'quiet', False):
+            # TODO print something here
+            pass
+        return 1
+
+    with open(args.file, 'rb') as fp:
+        data = yaml.load(fp)
+
+    if args.only:
+        # TODO support . notation to acccess dependencies.pip, etc
+        for a in args.only.split(','):
+            print(data[a])
+
+    else:
+        for k, v in data.items():
+            print("%s == %s" % (k, v))


### PR DESCRIPTION
Add in support for doing `source activate` inside a directory with an `environment.yml` file and having it pick up that environment and activate it.

## Testing
In order to test this branch, you have to install conda from this branch: https://github.com/conda/conda/pull/1013.  From within a checkout of that branch, run:

    python setup.py develop


## Tasks
* [x] Add `source activate` support on *nix systems
* [ ] Handle situation where an environment has not been created
* [ ] Add `activate` support on Windows
* [ ] Verify all `test_activate` scripts in conda still pass
* [ ] Document usage