### PR TITLE
v1.4.2 release: fix oddball BASH issue

### DIFF
--- a/bin/env-activate
+++ b/bin/env-activate
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Ensure that this script is sourced, not executed
-# Note that if the script was executed, we're running inside bash!
-if [[ -n $BASH_VERSION ]] && [[ "$(basename $0)" == "activate" ]]; then
+# Also note that errors are ignored as `activate foo` doesn't generate a bad
+# value for $0 which would cause errors.
+if [[ -n $BASH_VERSION ]] && [[ "$(basename "$0" 2> /dev/null)" == "activate" ]]; then
     >&2 echo "Error: activate must be sourced. Run 'source activate envname'
 instead of 'activate envname'.
 "

--- a/bin/env-deactivate
+++ b/bin/env-deactivate
@@ -2,7 +2,9 @@
 
 # Ensure that this script is sourced, not executed
 # Note that if the script was executed, we're running inside bash!
-if [[ -n $BASH_VERSION ]] && [[ "$(basename $0)" == "deactivate" ]]; then
+# Also note that errors are ignored as `activate foo` doesn't generate a bad
+# value for $0 which would cause errors.
+if [[ -n $BASH_VERSION ]] && [[ "$(basename "$0" 2> /dev/null)" == "deactivate" ]]; then
     >&2 echo "Error: deactivate must be sourced. Run 'source deactivate'
 instead of 'deactivate'.
 "

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-env
-  version: 1.4.1
+  version: 1.4.2alpha
 
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ else:
 
 setup(
     name="conda-env",
-    version="1.4.1",
+    version="1.4.2alpha",
     author="Continuum Analytics, Inc.",
     author_email="support@continuum.io",
     url="https://github.com/conda/conda-env",


### PR DESCRIPTION
From commit log:

> I've got an issue, probably related to my highly customized bash prompt, where $0 == "-/bin/bash".  That cases errors when passed to `basename` because thinks that's a parameter and tries to treat it as such.  This modifies the code to ignore those errors.  The path that its attempting to detect is a direct call to "activate" or "deactivate" which won't trigger those errors.