### PR TITLE
Remove runtime dependency on setuptools

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -16,7 +16,6 @@ requirements:
     - setuptools
   run:
     - python
-    - setuptools
 
 test:
   commands:

--- a/conda_env/installers/base.py
+++ b/conda_env/installers/base.py
@@ -1,6 +1,4 @@
-import pkg_resources
-
-ENTRY_POINT = 'conda.env.installers'
+ENTRY_POINT = 'conda_env.installers'
 
 
 class InvalidInstaller(Exception):
@@ -10,8 +8,7 @@ class InvalidInstaller(Exception):
 
 
 def get_installer(name):
-    for entry_point in pkg_resources.iter_entry_points(ENTRY_POINT):
-        if entry_point.name == name:
-            return entry_point.load()
-
-    raise InvalidInstaller(name)
+    try:
+        return __import__(ENTRY_POINT + '.' + name)
+    except ImportError:
+        raise InvalidInstaller(name)


### PR DESCRIPTION
To install an installer plugin, one simply needs to install a .py file with
the desired name to site-packages/conda_env/installers/

I didn't change any documentation yet (if there is any).