### PR TITLE
Fix windows activate.bat script

### DIFF
--- a/bin/activate.bat
+++ b/bin/activate.bat
@@ -32,27 +32,27 @@ if "%CONDA_DEFAULT_ENV%" == "" goto skipdeactivate
     echo Deactivating environment "%CONDA_DEFAULT_ENV%"...
 
     REM Run any deactivate scripts
-    if not exist "%ANACONDA_ENVS%\%CONDA_DEFAULT_ENV%\etc\conda\deactivate.d" goto nodeactivate
-        pushd "%ANACONDA_ENVS%\%CONDA_DEFAULT_ENV%\etc\conda\deactivate.d"
+    if not exist "%CONDA_DEFAULT_ENV%\etc\conda\deactivate.d" goto nodeactivate
+        pushd "%CONDA_DEFAULT_ENV%\etc\conda\deactivate.d"
         for %%g in (*.bat) do call "%%g"
         popd
     :nodeactivate
 
-    set CONDACTIVATE_PATH=%ANACONDA_ENVS%\%CONDA_DEFAULT_ENV%;%ANACONDA_ENVS%\%CONDA_DEFAULT_ENV%\Scripts;
+    set CONDACTIVATE_PATH=%CONDA_DEFAULT_ENV%;%CONDA_DEFAULT_ENV%\Scripts;
     call set PATH=%%PATH:%CONDACTIVATE_PATH%=%%
     set CONDA_DEFAULT_ENV=
     set CONDACTIVATE_PATH=
 :skipdeactivate
 
-set CONDA_DEFAULT_ENV=%CONDA_NEW_ENV%
+set CONDA_DEFAULT_ENV=%ANACONDA_ENVS%\%CONDA_NEW_ENV%
 set CONDA_NEW_ENV=
 echo Activating environment "%CONDA_DEFAULT_ENV%"...
-set PATH=%ANACONDA_ENVS%\%CONDA_DEFAULT_ENV%;%ANACONDA_ENVS%\%CONDA_DEFAULT_ENV%\Scripts;%PATH%
+set PATH=%CONDA_DEFAULT_ENV%;%CONDA_DEFAULT_ENV%\Scripts;%PATH%
 set PROMPT=[%CONDA_DEFAULT_ENV%] $P$G
 
 REM Run any activate scripts
-if not exist "%ANACONDA_ENVS%\%CONDA_DEFAULT_ENV%\etc\conda\activate.d" goto noactivate
-    pushd "%ANACONDA_ENVS%\%CONDA_DEFAULT_ENV%\etc\conda\activate.d"
+if not exist "%CONDA_DEFAULT_ENV%\etc\conda\activate.d" goto noactivate
+    pushd "%CONDA_DEFAULT_ENV%\etc\conda\activate.d"
     for %%g in (*.bat) do call "%%g"
     popd
 :noactivate

--- a/bin/activate.bat
+++ b/bin/activate.bat
@@ -21,11 +21,17 @@ if not "%CONDA_NEW_NAME%" == "" goto skipmissingarg
 :skipmissingarg
 
 if exist "%ANACONDA_ENVS%\%CONDA_NEW_NAME%\conda-meta" goto usenamedenv
-    echo No environment named "%CONDA_NEW_NAME%" exists in %ANACONDA_ENVS%
-    set CONDA_NEW_NAME=
-    exit /b 1
+    for /F %%i in ("%CONDA_NEW_NAME%") do set CONDA_NEW_PATH=%%~fi
+    if exist "%CONDA_NEW_PATH%\conda-meta" goto usefullpath
+        echo No environment named "%CONDA_NEW_NAME%" exists in %ANACONDA_ENVS%
+        set CONDA_NEW_NAME=
+        set CONDA_NEW_PATH=
+        exit /b 1
 :usenamedenv
     set CONDA_NEW_PATH=%ANACONDA_ENVS%\%CONDA_NEW_NAME%
+    goto skipmissingenv
+:usefullpath
+    for /F %%i in ("%CONDA_NEW_PATH%") do set CONDA_NEW_NAME=%%~ni
 :skipmissingenv
 
 REM Deactivate a previous activation if it is live

--- a/bin/activate.bat
+++ b/bin/activate.bat
@@ -4,14 +4,14 @@ for /f "delims=" %%i in ("%~dp0..\envs") do (
     set ANACONDA_ENVS=%%~fi
 )
 
-set CONDA_NEW_ENV=%~1
+set CONDA_NEW_NAME=%~1
 
 if "%~2" == "" goto skiptoomanyargs
     echo ERROR: Too many arguments provided
     goto usage
 :skiptoomanyargs
 
-if not "%CONDA_NEW_ENV%" == "" goto skipmissingarg
+if not "%CONDA_NEW_NAME%" == "" goto skipmissingarg
 :usage
     echo Usage: activate envname
     echo.
@@ -20,10 +20,12 @@ if not "%CONDA_NEW_ENV%" == "" goto skipmissingarg
     exit /b 1
 :skipmissingarg
 
-if exist "%ANACONDA_ENVS%\%CONDA_NEW_ENV%\conda-meta" goto skipmissingenv
-    echo No environment named "%CONDA_NEW_ENV%" exists in %ANACONDA_ENVS%
-    set CONDA_NEW_ENV=
+if exist "%ANACONDA_ENVS%\%CONDA_NEW_NAME%\conda-meta" goto usenamedenv
+    echo No environment named "%CONDA_NEW_NAME%" exists in %ANACONDA_ENVS%
+    set CONDA_NEW_NAME=
     exit /b 1
+:usenamedenv
+    set CONDA_NEW_PATH=%ANACONDA_ENVS%\%CONDA_NEW_NAME%
 :skipmissingenv
 
 REM Deactivate a previous activation if it is live
@@ -44,11 +46,12 @@ if "%CONDA_DEFAULT_ENV%" == "" goto skipdeactivate
     set CONDACTIVATE_PATH=
 :skipdeactivate
 
-set CONDA_DEFAULT_ENV=%ANACONDA_ENVS%\%CONDA_NEW_ENV%
-set CONDA_NEW_ENV=
+set CONDA_DEFAULT_ENV=%CONDA_NEW_PATH%
 echo Activating environment "%CONDA_DEFAULT_ENV%"...
 set PATH=%CONDA_DEFAULT_ENV%;%CONDA_DEFAULT_ENV%\Scripts;%PATH%
-set PROMPT=[%CONDA_DEFAULT_ENV%] $P$G
+set PROMPT=[%CONDA_NEW_NAME%] $P$G
+set CONDA_NEW_NAME=
+set CONDA_NEW_PATH=
 
 REM Run any activate scripts
 if not exist "%CONDA_DEFAULT_ENV%\etc\conda\activate.d" goto noactivate

--- a/bin/deactivate.bat
+++ b/bin/deactivate.bat
@@ -19,13 +19,13 @@ if "%CONDA_DEFAULT_ENV%" == "" goto skipdeactivate
     echo Deactivating environment "%CONDA_DEFAULT_ENV%"...
 
     REM Run any deactivate scripts
-    if not exist "%ANACONDA_ENVS%\%CONDA_DEFAULT_ENV%\etc\conda\deactivate.d" goto nodeactivate
-        pushd "%ANACONDA_ENVS%\%CONDA_DEFAULT_ENV%\etc\conda\deactivate.d"
+    if not exist "%CONDA_DEFAULT_ENV%\etc\conda\deactivate.d" goto nodeactivate
+        pushd "%CONDA_DEFAULT_ENV%\etc\conda\deactivate.d"
         for %%g in (*.bat) do call "%%g"
         popd
     :nodeactivate
 
-    set CONDACTIVATE_PATH=%ANACONDA_ENVS%\%CONDA_DEFAULT_ENV%;%ANACONDA_ENVS%\%CONDA_DEFAULT_ENV%\Scripts;
+    set CONDACTIVATE_PATH=%CONDA_DEFAULT_ENV%;%CONDA_DEFAULT_ENV%\Scripts;
     call set PATH=%%PATH:%CONDACTIVATE_PATH%=%%
     set CONDA_DEFAULT_ENV=
     set CONDACTIVATE_PATH=


### PR DESCRIPTION
Correctly handles paths (not names) arguments in activate.bat.

Fixes #59

Note: `CONDA_DEFAULT_ENV` is now always a full path.