### PR TITLE
Allow third party integration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Provides the `conda env` interface to Conda environments.
 Installing
 ----------
 
-To install `conda env` with conda, run the following command in your root environment: 
+To install `conda env` with conda, run the following command in your root environment:
 
 .. code-block:: bash
 
@@ -73,3 +73,127 @@ You can override the name of the created channel by providing either ``-n`` or
 ``--name`` and a valid environment name.  Likewise, you can explicitly provide
 an environment spec file using ``-f`` or ``--file`` and the name of the file you
 would like to use.
+
+
+Extension of CLI
+----------------
+All commands are extendable by using entry points.  Care must be taken when
+writing extensions as they change the way commands are executed.
+
+There are two entry points for every ``main_`` module the ``conda_env.cli``
+module:
+
+``configure_parser``
+    You use this to add command line arguments
+``execute``
+    You use this to adjust the execution of the actual command
+
+You can register one or both of these entry points.  Generally, you should add
+command line arguments in your ``configure_parser`` code that triggers behavior
+in your your ``execute`` entry point.
+
+The easiest way to understand how these work is to see them in action. Let's
+create an extension to the ``conda env create`` command that adds ``--say``.
+When it's added, the extension will print out the name of the environment when
+it's done.
+
+I'm going to create this as the ``conda_env_say`` module, but it could be named
+anything.  You're going to need a ``setup.py`` file, so create that and make
+sure to use ``setuptools.setup`` and not ``distutils.core.setup``.  The latter
+does not have the required support for entry points.
+
+Inside your ``setup.py``, add the following:
+
+.. code-block:: python
+
+    entry_points={
+        'conda_env.cli.main_create.configure_parser': [
+            'say = conda_env_say:say_configure_parser',
+        ],
+        'conda_env.cli.main_create.execute': [
+            'say = conda_env_say:say_execute',
+        ]
+    }
+
+This code adds the functions ``say_configure_parser`` and ``say_execute`` from
+the ``conda_env_say`` module to their respective entry points.  The syntax
+you're using here is a dictionary of entry points.  The keys,
+``conda_env.cli.main_create.configure_parser`` and
+``conda_env.cli.main_create.execute``, tell setuptools what entry points to
+register with and the values are the functions you want to register.  For this
+you need to include a unique name (it can be anything, Conda doesn't use it
+currently, but may in the future), the name of the module where your code is
+located, and the function you want to add.
+
+Next up, you need to write your handlers for each of these new entry points.
+You should create a ``say_configure_parser`` function that looks like this:
+
+.. code-block:: python
+
+    def say_configure_parser(sub_parsers):
+        p = say_configure_parser.next(sub_parsers)
+        p.add_argument('--say', action='store_true', default=False,
+                       help='say the name')
+        return p
+
+There are a couple of things going on here.  Note that the function arguments
+are the same as the ``conda_env.cli.main_create.configure_parser`` function,
+just a ``sub_parsers`` argument.  That's provided from Conda.  The first line
+we call ``say_configure_parser.next``.  This function is added by Conda to
+allow you to control how this extension handles calling the main code base.
+
+.. warning::
+
+    You *must* invoke ``your_function.next`` with the arguments provided when
+    it's executed or Conda will not behave like it should.  You must also return
+    the result from ``your_function.next`` so your code plays nicely with
+    other's.  You might not be the only extension installed.
+
+The result of ``next`` is the sub parser that's generated for the ``conda env
+create`` command.  You can add your own arguments to that, other sub parsers,
+or generally anything that you can do with parsers.
+
+Once that's in place, you need to add the execution code.  Add this to your
+module:
+
+.. code-block:: python
+
+    def say_execute(args, parser):
+        if args.say:
+            if args.name:
+                print("you're about to create %s" % args.name)
+            else:
+                print("you're about to create an environment, but I don't know "
+                      "what the name is yet")
+        return say_execute.next(args, parser)
+
+This code checks to see if ``--say`` was used from the command line.  When it's
+present, it starts trying to display the name.  Conda might note know the name
+of the environment at this point since it can also read it from the
+``environment.yml`` file.  Depending on whether ``--name`` was explicitly used
+or not, this outputs a statement to the user, then continues.
+
+Note again that it calls ``.next`` on the function it self.  That's put there
+by Conda, just like the one you used in ``say_configure_parser``.  You *must*
+call it and return its result if you want the normal behavior to execute.
+
+Now if you install your new code and run ``conda env create --help`` you'll see
+your new option:
+
+.. code-block:: console
+
+    ❯ conda env create --help
+    usage: conda-env create [-h] [-n NAME] [-f FILE] [-q QUIET] [--json] [--say]
+
+    Create an environment based on an environment file
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -n NAME, --name NAME  name of environment (in /Users/travis/anaconda/envs)
+      -f FILE, --file FILE  environment definition (default: environment.yml)
+      -q QUIET, --quiet QUIET
+      --json                report all output as json. Suitable for using conda
+                            programmatically.
+      --say                 say the name
+
+Congratulations!  You've written your first Conda extension.

--- a/conda_env/cli/helpers.py
+++ b/conda_env/cli/helpers.py
@@ -15,6 +15,15 @@ def generate_entry_points(name):
 
 # TODO Extract to third-party package
 def enable_entry_point_override(entry_point_name):
+    """
+    Wraps a given function with entry point calls that can override behavior
+
+    Use this to add a middleware like layer to a function call.  It's used
+    inside conda_env to allow third-party code to change the behavior of the
+    various subcommands.  For example, you can add a hook that provides an
+    additional parameter via the configure_parser hook, then if you detect that
+    behavior, change code execution appropriately inside your execute hook.
+    """
     def outer(func):
         @wraps(func)
         def inner(*args, **kwargs):

--- a/conda_env/cli/helpers.py
+++ b/conda_env/cli/helpers.py
@@ -18,8 +18,6 @@ def generate_next(func, after):
         return after(*args, **kwargs)
 
     def wrapper(*args, **kwargs):
-        print("calling %s with args %s / kwargs %s" % (func, args, kwargs))
-
         func.next = next
         return func(*args, **kwargs)
     return wrapper

--- a/conda_env/cli/helpers.py
+++ b/conda_env/cli/helpers.py
@@ -2,6 +2,7 @@ from functools import wraps
 import pkg_resources
 
 
+# TODO Extract to third-party package
 def generate_entry_points(name):
     """
     Internal function for generating command entry points
@@ -12,6 +13,7 @@ def generate_entry_points(name):
     }
 
 
+# TODO Extract to third-party package
 def enable_entry_point_override(entry_point_name):
     def outer(func):
         @wraps(func)

--- a/conda_env/cli/helpers.py
+++ b/conda_env/cli/helpers.py
@@ -40,7 +40,7 @@ def enable_entry_point_override(entry_point_name):
             entry_points = pkg_resources.iter_entry_points(entry_point_name)
 
             next_func = func
-            for entry_point in reversed(entry_points):
+            for entry_point in reversed(list(entry_points)):
                 next_func = generate_next(entry_point.load(), next_func)
             return next_func(*args, **kwargs)
         return inner

--- a/conda_env/cli/helpers.py
+++ b/conda_env/cli/helpers.py
@@ -1,3 +1,7 @@
+from functools import wraps
+import pkg_resources
+
+
 def generate_entry_points(name):
     """
     Internal function for generating command entry points
@@ -6,3 +10,17 @@ def generate_entry_points(name):
         "configure_parser": "%s.configure_parser" % name,
         "execute": "%s.execute" % name,
     }
+
+
+def enable_entry_point_override(entry_point_name):
+    def outer(func):
+        @wraps(func)
+        def inner(*args, **kwargs):
+            entry_points = pkg_resources.iter_entry_points(entry_point_name)
+            for entry_point in entry_points:
+                ret = entry_point.load()(*args, **kwargs)
+                if ret is not None:
+                    return ret
+            return func(*args, **kwargs)
+        return inner
+    return outer

--- a/conda_env/cli/helpers.py
+++ b/conda_env/cli/helpers.py
@@ -1,0 +1,8 @@
+def generate_entry_points(name):
+    """
+    Internal function for generating command entry points
+    """
+    return {
+        "configure_parser": "%s.configure_parser" % name,
+        "execute": "%s.execute" % name,
+    }

--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -13,11 +13,9 @@ from conda.misc import touch_nonadmin
 from ..env import from_file
 from ..installers.base import get_installer, InvalidInstaller
 from .. import exceptions
+from . import helpers
 
-ENTRY_POINTS = {
-    "configure_parser": "%s.configure_parser" % __name__,
-    "execute": "%s.execute" % __name__,
-}
+ENTRY_POINTS = helpers.generate_entry_points(__name__)
 
 description = """
 Create an environment based on an environment file

--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -67,12 +67,6 @@ def configure_parser(sub_parsers):
     )
     common.add_parser_json(p)
 
-    entry_points = pkg_resources.iter_entry_points(
-        ENTRY_POINTS["configure_parser"]
-    )
-    for entry_point in entry_points:
-        entry_point.load()(p)
-
     p.set_defaults(func=execute)
 
 

--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -30,14 +30,21 @@ examples:
 """
 
 
-def sub_parser(p):
-    print("sub_parser invoked")
-    return sub_parser.next(p)
+def say_configure_parser(sub_parsers):
+    p = say_configure_parser.next(sub_parsers)
+    p.add_argument('--say', action='store_true', default=False,
+                   help='say the name')
+    return p
 
 
-def sub_execute(args, parser):
-    print("sub_execute invoked")
-    return sub_execute.next(args, parser)
+def say_execute(args, parser):
+    if args.say:
+        if args.name:
+            print("you're about to create %s" % args.name)
+        else:
+            print("you're about to create an environment, but I don't know "
+                  "what the name is yet")
+    return say_execute.next(args, parser)
 
 
 @helpers.enable_entry_point_override(ENTRY_POINTS["configure_parser"])

--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -76,23 +76,7 @@ def configure_parser(sub_parsers):
     p.set_defaults(func=execute)
 
 
-def allow_entry_point_override(name):
-    def outer(func):
-        def inner(*args, **kwargs):
-            entry_points = pkg_resources.iter_entry_points(
-                ENTRY_POINTS["execute"]
-            )
-            for entry_point in entry_points:
-                ep = entry_point.load()
-                ret = ep(*args, **kwargs)
-                if ret is not None:
-                    return ret
-            return func(*args, **kwargs)
-        return inner
-    return outer
-
-
-@allow_entry_point_override(ENTRY_POINTS["execute"])
+@helpers.enable_entry_point_override(ENTRY_POINTS["execute"])
 def execute(args, parser):
     try:
         env = from_file(args.file)

--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -32,13 +32,15 @@ examples:
 
 def sub_parser(p):
     print("sub_parser invoked")
+    return sub_parser.next(p)
 
 
 def sub_execute(args, parser):
     print("sub_execute invoked")
-    return
+    return sub_execute.next(args, parser)
 
 
+@helpers.enable_entry_point_override(ENTRY_POINTS["configure_parser"])
 def configure_parser(sub_parsers):
     p = sub_parsers.add_parser(
         'create',
@@ -68,6 +70,7 @@ def configure_parser(sub_parsers):
     common.add_parser_json(p)
 
     p.set_defaults(func=execute)
+    return p
 
 
 @helpers.enable_entry_point_override(ENTRY_POINTS["execute"])

--- a/conda_env/cli/main_export.py
+++ b/conda_env/cli/main_export.py
@@ -8,6 +8,9 @@ from conda.cli import common
 from conda import config
 
 from ..env import from_environment
+from . import helpers
+
+ENTRY_POINTS = helpers.generate_entry_points(__name__)
 
 description = """
 Export a given environment
@@ -46,6 +49,7 @@ def configure_parser(sub_parsers):
 
 
 # TODO Make this aware of channels that were used to install packages
+@helpers.enable_entry_point_override(ENTRY_POINTS["execute"])
 def execute(args, parser):
     if not args.name:
         # Note, this is a hack fofr get_prefix that assumes argparse results

--- a/conda_env/cli/main_export.py
+++ b/conda_env/cli/main_export.py
@@ -23,6 +23,7 @@ examples:
 """
 
 
+@helpers.enable_entry_point_override(ENTRY_POINTS["configure_parser"])
 def configure_parser(sub_parsers):
     p = sub_parsers.add_parser(
         'export',
@@ -46,6 +47,7 @@ def configure_parser(sub_parsers):
     )
 
     p.set_defaults(func=execute)
+    return p
 
 
 # TODO Make this aware of channels that were used to install packages

--- a/conda_env/cli/main_list.py
+++ b/conda_env/cli/main_list.py
@@ -2,6 +2,10 @@ from argparse import RawDescriptionHelpFormatter
 
 from conda.cli import common
 
+from . import helpers
+
+ENTRY_POINTS = helpers.generate_entry_points(__name__)
+
 description = """
 List the Conda environments
 """
@@ -27,6 +31,7 @@ def configure_parser(sub_parsers):
     l.set_defaults(func=execute)
 
 
+@helpers.enable_entry_point_override(ENTRY_POINTS["execute"])
 def execute(args, parser):
     info_dict = {'envs': []}
     common.handle_envs_list(info_dict['envs'], not args.json)

--- a/conda_env/cli/main_list.py
+++ b/conda_env/cli/main_list.py
@@ -17,6 +17,7 @@ examples:
 """
 
 
+@helpers.enable_entry_point_override(ENTRY_POINTS["configure_parser"])
 def configure_parser(sub_parsers):
     l = sub_parsers.add_parser(
         'list',
@@ -29,6 +30,7 @@ def configure_parser(sub_parsers):
     common.add_parser_json(l)
 
     l.set_defaults(func=execute)
+    return l
 
 
 @helpers.enable_entry_point_override(ENTRY_POINTS["execute"])

--- a/conda_env/cli/main_remove.py
+++ b/conda_env/cli/main_remove.py
@@ -5,6 +5,10 @@ import textwrap
 
 from conda.cli import common
 
+from . import helpers
+
+ENTRY_POINTS = helpers.generate_entry_points(__name__)
+
 _help = "Remove an environment"
 _description = _help + """
 
@@ -38,6 +42,7 @@ def configure_parser(sub_parsers):
     p.set_defaults(func=execute)
 
 
+@helpers.enable_entry_point_override(ENTRY_POINTS["execute"])
 def execute(args, parser):
     from conda import config, plan
     from conda.install import linked, rm_rf

--- a/conda_env/cli/main_remove.py
+++ b/conda_env/cli/main_remove.py
@@ -25,6 +25,7 @@ Examples:
 """
 
 
+@helpers.enable_entry_point_override(ENTRY_POINTS["configure_parser"])
 def configure_parser(sub_parsers):
     p = sub_parsers.add_parser(
         'remove',
@@ -40,6 +41,7 @@ def configure_parser(sub_parsers):
     common.add_parser_yes(p)
 
     p.set_defaults(func=execute)
+    return p
 
 
 @helpers.enable_entry_point_override(ENTRY_POINTS["execute"])

--- a/conda_env/cli/main_update.py
+++ b/conda_env/cli/main_update.py
@@ -27,6 +27,7 @@ examples:
     conda env update --name=foo --file=environment.yml
 """
 
+@helpers.enable_entry_point_override(ENTRY_POINTS["configure_parser"])
 def configure_parser(sub_parsers):
     p = sub_parsers.add_parser(
         'update',
@@ -55,6 +56,7 @@ def configure_parser(sub_parsers):
     )
     common.add_parser_json(p)
     p.set_defaults(func=execute)
+    return p
 
 
 @helpers.enable_entry_point_override(ENTRY_POINTS["execute"])

--- a/conda_env/cli/main_update.py
+++ b/conda_env/cli/main_update.py
@@ -11,6 +11,9 @@ from conda.misc import touch_nonadmin
 from ..env import from_file
 from ..installers.base import get_installer, InvalidInstaller
 from .. import exceptions
+from . import helpers
+
+ENTRY_POINTS = helpers.generate_entry_points(__name__)
 
 description = """
 Update the current environment based on environment file
@@ -54,6 +57,7 @@ def configure_parser(sub_parsers):
     p.set_defaults(func=execute)
 
 
+@helpers.enable_entry_point_override(ENTRY_POINTS["execute"])
 def execute(args, parser):
     try:
         env = from_file(args.file)

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "Programming Language :: Python :: 3.3",
     ],
     description="tools for interacting with conda environments",
-    long_description=open('README.rst').read(),
+    long_description=open('README.rst', 'rb').read().decode('UTF-8'),
     packages=[
         'conda_env',
         'conda_env.cli',

--- a/setup.py
+++ b/setup.py
@@ -48,10 +48,10 @@ setup(
     ],
     entry_points={
         'conda_env.cli.main_create.configure_parser': [
-            'one = conda_env.cli.main_create:sub_parser',
+            'say = conda_env.cli.main_create:say_configure_parser',
         ],
         'conda_env.cli.main_create.execute': [
-            'one = conda_env.cli.main_create:sub_execute',
+            'say = conda_env.cli.main_create:say_execute',
         ]
     },
     scripts=[

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,14 @@ setup(
         'conda_env.cli',
         'conda_env.installers',
     ],
+    entry_points={
+        'conda_env.cli.main_create.configure_parser': [
+            'one = conda_env.cli.main_create:sub_parser',
+        ],
+        'conda_env.cli.main_create.execute': [
+            'one = conda_env.cli.main_create:sub_execute',
+        ]
+    },
     scripts=[
         'bin/conda-env',
     ] + scripts,

--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -1,0 +1,35 @@
+import random
+from unittest import TestCase
+
+from conda_env.cli import helpers
+
+
+class GenerateEntryPointsTestCase(TestCase):
+    def test_requires_one_argument(self):
+        with self.assertRaises(TypeError):
+            helpers.generate_entry_points()
+            helpers.generate_entry_points("one", "two")
+
+    def test_returns_dictionary(self):
+        eps = helpers.generate_entry_points("foo")
+        self.assertIsInstance(eps, dict)
+
+    def test_has_configure_parser(self):
+        eps = helpers.generate_entry_points("foo")
+        self.assertTrue("configure_parser" in eps)
+
+    def test_has_execute(self):
+        eps = helpers.generate_entry_points("foo")
+        self.assertTrue("execute" in eps)
+
+    def test_configure_parser_maps_to_proper_entry_point_name(self):
+        random_module = "some.module.foo%d" % random.randint(1000, 2000)
+        eps = helpers.generate_entry_points(random_module)
+        expected = "%s.configure_parser" % random_module
+        self.assertEqual(expected, eps["configure_parser"])
+
+    def test_execute_maps_to_proper_entry_point_name(self):
+        random_module = "some.module.foo%d" % random.randint(1000, 2000)
+        eps = helpers.generate_entry_points(random_module)
+        expected = "%s.execute" % random_module
+        self.assertEqual(expected, eps["execute"])

--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -153,8 +153,9 @@ def mock_execute_entry_point(custom_execute=None):
     entry_point = mock.Mock()
     entry_point.load.return_value = custom_execute
 
+    def mock_iter_entry_points(name):
+        yield entry_point
+
     with mock.patch.object(helpers, "pkg_resources") as pkg_resources:
-        pkg_resources.iter_entry_points = mock.Mock(
-            return_value=[entry_point]
-        )
+        pkg_resources.iter_entry_points = mock_iter_entry_points
         yield custom_execute


### PR DESCRIPTION
This came out of a conversation with @quasiben about ways to avoid adding a ton of duplicate commands when dealing with add-ons such as the tooling for Anaconda Cluster.  Currently, the command must look something like this:

``` console
$ conda cluster --cluster-name=foo create ... rest of arguments
# or...
$ conda cluster foo create ... rest of arguments
```

This new code allows integration directly with `conda env create` by allowing that package to register its own parameters via `conda_env.cli.main_create.configure_parser` and a custom execution method with `conda_env.cli.main_create.execute`.  Under this system, the API would be:

``` console
$ conda env create --cluster foo ... rest of arguments
```

The idea here is to allow hooking in to any command and circumventing it.  In the case of Anaconda Cluster, it's to take a command that runs locally and dispatch it to a cluster of machines.
## Tasks
- [x] Proof of concept
- [x] Build out tests for all decoration code
- [x] Allow code to act as full middleware where it can change behavior before _and_ after the main execute() has run
- [x] Document new extension point
