### PR TITLE
ENH : sort activate.d scripts to control order

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -32,7 +32,7 @@ run_scripts() {
     _PREFIX="$(echo $(echo $PATH | awk -F ':' '{print $1}')/..)"
     _CONDA_D="${_PREFIX}/etc/conda/$1.d"
     if [[ -d $_CONDA_D ]]; then
-        for f in $(find $_CONDA_D -name "*.sh"); do source $f; done
+        for f in $(find $_CONDA_D -name "*.sh" | sort); do source $f; done
     fi
 }
 

--- a/bin/deactivate
+++ b/bin/deactivate
@@ -39,7 +39,7 @@ run_scripts() {
     _PREFIX="$(echo $(echo $PATH | awk -F ':' '{print $1}')/..)"
     _CONDA_D="${_PREFIX}/etc/conda/$1.d"
     if [[ -d $_CONDA_D ]]; then
-        for f in $(find $_CONDA_D -name "*.sh"); do source $f; done
+        for f in $(find $_CONDA_D -name "*.sh" | sort); do source $f; done
     fi
 }
 


### PR DESCRIPTION
Sort the found shell scripts to allow the user to control which order
the scripts are run in.

I don't know enough to make the parallel change in the windows files.

The reason I want this is because I am trying to use conda packages to manage the setup/teardown of a test environment where I need to start a server-like thing, but some environmental variables need to be set first.

It currently sorts on the path to the scripts which is fine if you don't have anything in directories.  I am not convinced that this is not the desired behavior, just aware of the concern.