### PR TITLE
avoid enlarging prompt with multiple activate

### DIFF
--- a/bin/activate.bat
+++ b/bin/activate.bat
@@ -48,8 +48,11 @@ set CONDA_DEFAULT_ENV=%CONDA_NEW_ENV%
 set CONDA_NEW_ENV=
 echo Activating environment "%CONDA_DEFAULT_ENV%"...
 set PATH=%ANACONDA_ENVS%\%CONDA_DEFAULT_ENV%;%ANACONDA_ENVS%\%CONDA_DEFAULT_ENV%\Scripts;%PATH%
-set CONDA_OLD_PROMPT=%PROMPT%
-set PROMPT=[%CONDA_DEFAULT_ENV%] %PROMPT%
+
+if not "%CONDA_OLD_PROMPT%" == "" goto skipoldprompt
+    set CONDA_OLD_PROMPT=%PROMPT%
+:skipoldprompt
+set PROMPT=[%CONDA_DEFAULT_ENV%] %CONDA_OLD_PROMPT%
 
 REM Run any activate scripts
 if not exist "%ANACONDA_ENVS%\%CONDA_DEFAULT_ENV%\etc\conda\activate.d" goto noactivate


### PR DESCRIPTION
If you activate several environments in turn on Windows, your prompt gets ever larger. eg, by activating "edge2" then "edge3" then "liam2" then "edge3", I just got:

[edge3] [liam2] [edge3] [edge2] C:\Users\gdm\devel\liam2>

I guess what you intended was something like above where only the initial prompt is remembered and recalled.