### PR TITLE
Add support for activate/deactivate scripts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,9 @@ All of the usage is documented via the ``--help`` flag.
 -------------------
 conda-env allows creating environments using the ``environment.yml``
 specification file.  This allows you to specify a name, channels to use when
-creating the environment, and the dependencies.  For example, to create an
-environment named ``stats`` with numpy and pandas create an ``environment.yml``
+creating the environment, dependencies and activate/deactivate scripts.
+
+To create an environment named ``stats`` with numpy and pandas create an ``environment.yml``
 file with this as the contents:
 
 .. code-block:: yaml
@@ -60,7 +61,7 @@ Then run this from the command line:
     [      COMPLETE      ] |#################################################| 100%
     #
     # To activate this environment, use:
-    # $ source activate numpy
+    # $ source activate stats
     #
     # To deactivate this environment, use:
     # $ source deactivate
@@ -73,3 +74,42 @@ You can override the name of the created channel by providing either ``-n`` or
 ``--name`` and a valid environment name.  Likewise, you can explicitly provide
 an environment spec file using ``-f`` or ``--file`` and the name of the file you
 would like to use.
+
+``environment.yml`` examples
+----------------------------
+
+Name and dependencies
+^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+    name: stats
+    dependencies:
+      - numpy
+      - pandas
+
+Name and version specific dependencies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+    name: stats
+    dependencies:
+      - numpy==1.8
+      - pandas==0.16.1
+
+
+Activate/deactivate scripts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+    name: oracle
+    dependencies:
+      - oracle_instantclient
+    
+    # Note that relative paths are relative to this file's location
+    activate:
+      - set_oraclehome.sh
+    deactivate:
+      - unset_oraclehome.sh

--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -105,6 +105,25 @@ def execute(args, parser):
             )
             return -1
 
+
+    # TODO should _link be moved to conda.misc?
+    # Use soft links to allow 'activate' scripts to obtain paths relative to its location
+    from conda.install import _link, LINK_SOFT
+
+    # Link activate scripts
+    if env.activate:
+        activate_dir = os.path.join(prefix, 'etc', 'conda', 'activate.d')
+        if not os.path.isdir(activate_dir): os.makedirs(activate_dir)
+        for i, activate_script in enumerate(env.activate):
+            _link(activate_script, os.path.join(activate_dir, '%s.sh' % i), LINK_SOFT)
+
+    # Link deactivate scripts
+    if env.deactivate:
+        deactivate_dir = os.path.join(prefix, 'etc', 'conda', 'deactivate.d')
+        if not os.path.isdir(deactivate_dir): os.makedirs(deactivate_dir)
+        for i, deactivate_script in enumerate(env.deactivate):
+            _link(deactivate_script, os.path.join(deactivate_dir, '%s.sh' % i), LINK_SOFT)
+
     touch_nonadmin(prefix)
     if not args.json:
         cli_install.print_activate(args.name if args.name else prefix)

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -81,14 +81,21 @@ class Dependencies(OrderedDict):
 
 class Environment(object):
     def __init__(self, name=None, filename=None, channels=None,
-                 dependencies=None):
+                 dependencies=None, activate=None, deactivate=None):
         self.name = name
         self.filename = filename
         self.dependencies = Dependencies(dependencies)
 
-        if channels is None:
-            channels = []
-        self.channels = channels
+        def abspath(path):
+            """Obtain an absolute path for ``path`` assuming it is relative to ``filename``"""
+            if filename is None or os.path.isabs(path):
+                return path
+            return os.path.abspath(os.path.join(os.path.dirname(filename), path))
+
+        self.channels = channels or []
+        self.dependencies = Dependencies(dependencies or [])
+        self.activate = map(abspath, activate or [])
+        self.deactivate = map(abspath, deactivate or [])
 
     def to_dict(self):
         d = yaml.dict([('name', self.name)])
@@ -96,6 +103,10 @@ class Environment(object):
             d['channels'] = self.channels
         if self.dependencies:
             d['dependencies'] = self.dependencies.raw
+        if self.activate:
+            d['activate'] = self.activate
+        if self.deactivate:
+            d['deactivate'] = self.deactivate
         return d
 
     def to_yaml(self, stream=None):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 import os
 import random
-import textwrap
 import unittest
 import yaml
 
@@ -203,6 +202,16 @@ class EnvironmentTestCase(unittest.TestCase):
         self.assert_(not 'bar' in e.dependencies['conda'])
         e.dependencies.add('bar')
         self.assert_('bar' in e.dependencies['conda'])
+
+
+    def test_activate(self):
+        e = env.Environment(activate=['script.sh'])
+        self.assertEqual(['script.sh'], e.activate)
+
+
+    def test_deactivate(self):
+        e = env.Environment(deactivate=['script.sh'])
+        self.assertEqual(['script.sh'], e.deactivate)
 
 
 class DirectoryTestCase(unittest.TestCase):


### PR DESCRIPTION
Scripts listed under 'activate' and 'deactivate' contexts in environment.yml will be linked into $PREFIX/etc/conda/(de)?activate.d, where they will be executed by 'source (de)?activate'

Relates to #83 