### PR TITLE
jinja2 + envvars and aliases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,3 +71,84 @@ in your local package cache.
 
 You can explicitly provide an environment spec file using ``-f`` or ``--file``
 and the name of the file you would like to use.
+
+
+``environment.yml`` jinja2 rendering
+------------------------------------
+
+If you have ``jinja2`` available in the environment, ``environment.yml`` files will be
+rendered with it before processing.
+
+.. code-block:: yaml
+
+    name: pytest
+    dependencies:
+    {% for i in ['xunit', 'coverage','mock'] %}
+      - pytest-{{ i }}
+    {% endfor %}
+
+In this example, the previous file with ``jinja2`` syntax is equivalent to:
+
+.. code-block:: yaml
+
+    name: pytest
+    dependencies:
+      - pytest-xunit
+      - pytest-coverage
+      - pytest-mock
+
+Available variables
+^^^^^^^^^^^^^^^^^^^
+
+When using ``jinja2``, on top of the usual template capabilities, you have access to the
+following variables:
+
+- ``root``: The directory containing ``environment.yml``
+- ``os``: Python's ``os`` module.
+
+
+``environment.yml`` examples
+----------------------------
+
+Name and dependencies
+^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+    name: stats
+    dependencies:
+      - numpy
+      - pandas
+
+Name and version specific dependencies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+    name: stats
+    dependencies:
+      - numpy==1.8
+      - pandas==0.16.1
+
+
+Environment/aliases
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+    name: oracle
+    dependencies:
+      - oracle_instantclient
+
+    # List type environment variables will be joined with os.pathsep (':' in unix, ';' in windows).
+    # These values will be inserted in front of any existing value in the current environment.
+    # e.g.:
+    #   current PATH: "/usr/local/bin:/usr/bin"
+    #   new     PATH: "{{ root }}/bin:/usr/local/bin:/usr/bin"
+    environment:
+      ORACLE_HOME: /usr/local/oracle_instantclient
+      PATH:
+        - {{ root }}/bin
+
+    aliases:
+      run_db: bash {{ root }}/bin/run_db.sh

--- a/bin/activate
+++ b/bin/activate
@@ -29,8 +29,7 @@ get_dirname() {
 }
 
 run_scripts() {
-    _PREFIX="$(echo $(echo $PATH | awk -F ':' '{print $1}')/..)"
-    _CONDA_D="${_PREFIX}/etc/conda/$1.d"
+    _CONDA_D="${CONDA_ENV_PATH}/etc/conda/$1.d"
     if [[ -d $_CONDA_D ]]; then
         for f in $(find $_CONDA_D -name "*.sh"); do source $f; done
     fi

--- a/bin/activate
+++ b/bin/activate
@@ -67,7 +67,9 @@ if (( $? == 0 )); then
         export CONDA_DEFAULT_ENV="$@"
     fi
 
-    export CONDA_ENV_PATH=$(get_dirname $_THIS_DIR)
+    # Get first path and convert it to absolute
+    ENV_BIN_DIR="$(echo $(echo $PATH | awk -F ':' '{print $1}'))"
+    export CONDA_ENV_PATH="$(get_dirname "$ENV_BIN_DIR")"
 
     if (( $("$_THIS_DIR/conda" ..changeps1) ));  then
             CONDA_OLD_PS1="$PS1"

--- a/bin/deactivate
+++ b/bin/deactivate
@@ -36,8 +36,7 @@ get_dirname() {
 }
 
 run_scripts() {
-    _PREFIX="$(echo $(echo $PATH | awk -F ':' '{print $1}')/..)"
-    _CONDA_D="${_PREFIX}/etc/conda/$1.d"
+    _CONDA_D="${CONDA_ENV_PATH}/etc/conda/$1.d"
     if [[ -d $_CONDA_D ]]; then
         for f in $(find $_CONDA_D -name "*.sh"); do source $f; done
     fi

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -89,14 +89,13 @@ class Dependencies(OrderedDict):
 
 class Environment(object):
     def __init__(self, name=None, filename=None, channels=None,
-                 dependencies=None):
+                 dependencies=None, environment=None, aliases=None):
         self.name = name
         self.filename = filename
         self.dependencies = Dependencies(dependencies)
-
-        if channels is None:
-            channels = []
-        self.channels = channels
+        self.channels = channels or []
+        self.environment = environment or {}
+        self.aliases = aliases or {}
 
     def to_dict(self):
         d = yaml.dict([('name', self.name)])
@@ -104,6 +103,10 @@ class Environment(object):
             d['channels'] = self.channels
         if self.dependencies:
             d['dependencies'] = self.dependencies.raw
+        if self.environment:
+            d['environment'] = self.environment
+        if self.aliases:
+            d['aliases'] = self.aliases
         return d
 
     def to_yaml(self, stream=None):

--- a/conda_env/exceptions.py
+++ b/conda_env/exceptions.py
@@ -49,3 +49,12 @@ class InvalidLoader(Exception):
     def __init__(self, name):
         msg = 'Unable to load installer for {}'.format(name)
         super(InvalidLoader, self).__init__(msg)
+
+
+# TODO: This is copied from conda_build. Could yaml parsing from both libraries
+# be merged instead of duplicated? This could include jinja2 and "# [unix]" flags.
+class UnableToParseMissingJinja2(CondaEnvRuntimeError):
+    def __init__(self, *args, **kwargs):
+        msg = 'It appears you are missing jinja2.  Please install that ' + \
+            'package, then attempt to create the environment.'
+        super(UnableToParseMissingJinja2, self).__init__(msg, *args, **kwargs)

--- a/conda_env/print_env.py
+++ b/conda_env/print_env.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+'''
+Supports:
+  * bash
+  * cmd.exe (windows default shell)
+  * tcc.exe (windows https://jpsoft.com/take-command-windows-scripting.html)
+'''
+from __future__ import print_function
+import os
+
+
+def print_env(action, environment={}, aliases={}):
+    # Determine shell
+    shell = os.environ.get('SHELL', os.environ.get('COMSPEC'))
+    if shell is None:
+        raise RuntimeError('Could not determine shell from environment variables {SHELL, COMSPEC}')
+    shell = os.path.basename(shell).lower()
+    pathsep = os.pathsep
+
+    # Create environment configuration functions
+    if shell == 'bash':
+        def Export(name, value):
+            if isinstance(value, basestring):
+                return 'export %(name)s=%(value)s\n' % locals()
+            else:
+                value = pathsep.join(value)
+                return 'export %(name)s=%(value)s%(pathsep)s$%(name)s\n' % locals()
+        def Unset(name):
+            return 'unset %(name)s\n' % locals()
+        def Alias(name, value):
+            return 'alias %(name)s="%(value)s"\n' % locals()
+        def Unalias(name):
+            return 'unalias %(name)s\n' % locals()
+
+    elif shell == 'cmd.exe':
+        def Export(name, value):
+            if isinstance(value, basestring):
+                return 'set %(name)s=%(value)s\n' % locals()
+            else:
+                value = pathsep.join(value)
+                return 'set %(name)s=%(value)s%(pathsep)s%%%(name)s%%\n' % locals()
+        def Unset(name):
+            return 'set %(name)s=\n' % locals()
+        def Alias(name, value):
+            return 'doskey %(name)s=%(value)s\n' % locals()
+        def Unalias(name):
+            return 'doskey %(name)s=\n' % locals()
+
+    elif shell == 'tcc.exe':
+        def Export(name, value):
+            if isinstance(value, basestring):
+                return 'set %(name)s=%(value)s\n' % locals()
+            else:
+                value = pathsep.join(value)
+                return 'set %(name)s=%(value)s%(pathsep)s%%%(name)s%%\n' % locals()
+        def Unset(name):
+            return 'set %(name)s=\n' % locals()
+        def Alias(name, value):
+            return 'alias %(name)s %(value)s\n' % locals()
+        def Unalias(name):
+            return 'unalias %(name)s\n' % locals()
+
+    # Activate/Deactivate
+    if action == 'activate':
+        s = ''
+        for k, v in sorted(environment.items()):
+            s += Export(k, v)
+        for k, v in sorted(aliases.items()):
+            s += Alias(k, v)
+        return s
+
+    elif action == 'deactivate':
+        s = ''
+        for k, v in sorted(environment.items()):
+            if k not in os.environ:
+                continue
+
+            if isinstance(v, basestring):
+                s += Unset(k)
+            else:
+                current_value = os.environ[k].split(os.pathsep)
+                current_value = [c for c in current_value if c != '']
+                for path in v:
+                    if path in current_value: current_value.remove(path)
+                if len(current_value) == 0:
+                    s += Unset(k)
+                else:
+                    s += Export(k, os.pathsep.join(current_value))
+
+        for alias in sorted(aliases):
+            s += Unalias(alias)
+        return s
+
+
+if __name__ == '__main__':
+    import sys
+
+    action = sys.argv[1]
+    environment = eval(sys.argv[2])
+    aliases = eval(sys.argv[3])
+
+    s = print_env(action, environment, aliases)
+    print(s)

--- a/conda_env/yaml.py
+++ b/conda_env/yaml.py
@@ -23,4 +23,5 @@ yaml.add_representer(OrderedDict, represent_ordereddict)
 
 dump = yaml.dump
 load = yaml.load
+parser = yaml.parser
 dict = OrderedDict

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,8 @@ setup(
         'conda_env',
         'conda_env.cli',
         'conda_env.installers',
+        'conda_env.specs',
+        'conda_env.utils',
     ],
     scripts=[
         'bin/conda-env',

--- a/tests/support/with-jinja.yml
+++ b/tests/support/with-jinja.yml
@@ -1,0 +1,9 @@
+name: with_jinja
+
+dependencies:
+{% for i in ['xunit', 'coverage','mock'] %}
+  - pytest-{{ i }}
+{% endfor %}
+
+environment:
+  PYTHON_DIR: {{ os.path.join(root, 'python') }}

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 import os
 import random
-import textwrap
 import unittest
 import yaml
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -42,6 +42,11 @@ class from_file_TestCase(unittest.TestCase):
         self.assert_('foo' in e.dependencies['pip'])
         self.assert_('baz' in e.dependencies['pip'])
 
+    def test_with_jinja(self):
+        e = env.from_file(utils.support_file('with-jinja.yml'))
+        self.assertEqual(e.dependencies.raw, ['pytest-xunit', 'pytest-coverage', 'pytest-mock'])
+        self.assertEqual(e.environment['PYTHON_DIR'], os.path.abspath(utils.support_file('python')))
+
 
 class EnvironmentTestCase(unittest.TestCase):
     def test_has_empty_filename_by_default(self):

--- a/tests/test_main_create.py
+++ b/tests/test_main_create.py
@@ -1,0 +1,83 @@
+import os
+import shutil
+import sys
+import textwrap
+import unittest
+
+from conda_env import env
+from conda_env.cli.main_create import write_activate_deactivate
+
+from . import utils
+
+
+class activate_deactivate_TestCase(unittest.TestCase):
+    _ENV = env.Environment(environment={'FOO' : 'BAR'}, aliases={'my_ls' : 'ls -la'})
+    _CONDA_DIR = utils.support_file('conda')
+    _PREFIX = os.path.join(_CONDA_DIR, 'envs', 'test_write_activate_deactivate')
+    _OBTAINED_PRINT_ENV = os.path.join(_PREFIX, 'etc', 'conda', 'print_env.py')
+    _EXPECTED_PRINT_ENV = os.path.join(
+        os.path.dirname(__file__),
+        '..',
+        'conda_env',
+        'print_env.py'
+    )
+
+    def test_write_activate_deactivate_unix(self):
+        old_platform = sys.platform
+        sys.platform = 'linux2'
+        try:
+            write_activate_deactivate(self._ENV, self._PREFIX)
+
+            with open(os.path.join(self._PREFIX, 'etc', 'conda', 'activate.d', '_activate.sh')) as activate:
+                self.assertEqual(activate.read(), textwrap.dedent(
+                    '''
+                    python "%s" activate "{\'FOO\': \'BAR\'}" "{\'my_ls\': \'ls -la\'}" > _tmp_activate.sh
+                    source _tmp_activate.sh
+                    rm _tmp_activate.sh
+                    '''
+                ).lstrip() % self._OBTAINED_PRINT_ENV)
+
+            with open(os.path.join(self._PREFIX, 'etc', 'conda', 'deactivate.d', '_deactivate.sh')) as deactivate:
+                self.assertEqual(deactivate.read(), textwrap.dedent(
+                    '''
+                    python "%s" deactivate "{\'FOO\': \'BAR\'}" "{\'my_ls\': \'ls -la\'}" > _tmp_deactivate.sh
+                    source _tmp_deactivate.sh
+                    rm _tmp_deactivate.sh
+                    '''
+                ).lstrip() % self._OBTAINED_PRINT_ENV)
+
+            with open(self._OBTAINED_PRINT_ENV) as obtained_print_env:
+                with open(self._EXPECTED_PRINT_ENV) as expected_print_env:
+                    self.assertEqual(obtained_print_env.read(), expected_print_env.read())
+        finally:
+            sys.platform = old_platform
+            shutil.rmtree(self._CONDA_DIR)
+
+
+    def test_write_activate_deactivate_win(self):
+        try:
+            write_activate_deactivate(self._ENV, self._PREFIX)
+
+            with open(os.path.join(self._PREFIX, 'etc', 'conda', 'activate.d', '_activate.bat')) as activate:
+                self.assertEqual(activate.read(), textwrap.dedent(
+                    '''
+                    python "%s" activate "{\'FOO\': \'BAR\'}" "{\'my_ls\': \'ls -la\'}" > _tmp_activate.bat
+                    call _tmp_activate.bat
+                    del _tmp_activate.bat
+                    '''
+                ).lstrip() % self._OBTAINED_PRINT_ENV)
+
+            with open(os.path.join(self._PREFIX, 'etc', 'conda', 'deactivate.d', '_deactivate.bat')) as deactivate:
+                self.assertEqual(deactivate.read(), textwrap.dedent(
+                    '''
+                    python "%s" deactivate "{\'FOO\': \'BAR\'}" "{\'my_ls\': \'ls -la\'}" > _tmp_deactivate.bat
+                    call _tmp_deactivate.bat
+                    del _tmp_deactivate.bat
+                    '''
+                ).lstrip() % self._OBTAINED_PRINT_ENV)
+
+            with open(self._OBTAINED_PRINT_ENV) as obtained_print_env:
+                with open(self._EXPECTED_PRINT_ENV) as expected_print_env:
+                    self.assertEqual(obtained_print_env.read(), expected_print_env.read())
+        finally:
+            shutil.rmtree(self._CONDA_DIR)

--- a/tests/test_print_env.py
+++ b/tests/test_print_env.py
@@ -1,0 +1,121 @@
+from conda_env.print_env import print_env
+import os
+import textwrap
+import unittest
+
+
+class EnvironmentAndAliasesTestCase(unittest.TestCase):
+
+    ENVIRONMENT = {
+        'PATH' : ['mypath1', 'mypath2'],
+        'ANY_LIST_REALLY' : ['something1', 'something2'],
+        'SINGLE_VAR' : 'single_value',
+    }
+    ALIASES = {
+        'my_ls' : 'ls -la'
+    }
+
+    def test_environment_and_aliases_bash(self):
+        old_environ = os.environ.copy()
+        old_pathsep = os.pathsep
+
+        try:
+            os.environ['SHELL'] = '/bin/bash'
+            os.pathsep = ':'
+
+            activate = print_env('activate', self.ENVIRONMENT, self.ALIASES)
+            assert activate == textwrap.dedent(
+                '''
+                export ANY_LIST_REALLY=something1:something2:$ANY_LIST_REALLY
+                export PATH=mypath1:mypath2:$PATH
+                export SINGLE_VAR=single_value
+                alias my_ls="ls -la"
+                '''
+            ).lstrip()
+
+            os.environ['PATH'] = '/usr/bin:mypath1:mypath2:/usr/local/bin'
+            os.environ['SINGLE_VAR'] = 'single_value'
+            os.environ['ANY_LIST_REALLY'] = 'something1:something2:'
+            deactivate = print_env('deactivate', self.ENVIRONMENT, self.ALIASES)
+            assert deactivate == textwrap.dedent(
+                '''
+                unset ANY_LIST_REALLY
+                export PATH=/usr/bin:/usr/local/bin
+                unset SINGLE_VAR
+                unalias my_ls
+                '''
+            ).lstrip()
+        finally:
+            os.environ.clear()
+            os.environ.update(old_environ)
+            os.pathsep = old_pathsep
+
+    def test_environment_and_aliases_cmd(self):
+        old_environ = os.environ.copy()
+        old_pathsep = os.pathsep
+
+        try:
+            os.environ['SHELL'] = 'C:\\Windows\\system32\\cmd.exe'
+            os.pathsep = ';'
+
+            activate = print_env('activate', self.ENVIRONMENT, self.ALIASES)
+            assert activate == textwrap.dedent(
+                '''
+                set ANY_LIST_REALLY=something1;something2;%ANY_LIST_REALLY%
+                set PATH=mypath1;mypath2;%PATH%
+                set SINGLE_VAR=single_value
+                doskey my_ls=ls -la
+                '''
+            ).lstrip()
+
+            os.environ['PATH'] = 'C:\\bin;mypath1;mypath2;C:\\Users\\me\\bin'
+            os.environ['SINGLE_VAR'] = 'single_value'
+            os.environ['ANY_LIST_REALLY'] = 'something1;something2;'
+            deactivate = print_env('deactivate', self.ENVIRONMENT, self.ALIASES)
+            assert deactivate == textwrap.dedent(
+                '''
+                set ANY_LIST_REALLY=
+                set PATH=C:\\bin;C:\\Users\\me\\bin
+                set SINGLE_VAR=
+                doskey my_ls=
+                '''
+            ).lstrip()
+        finally:
+            os.environ.clear()
+            os.environ.update(old_environ)
+            os.pathsep = old_pathsep
+
+    def test_environment_and_aliases_tcc(self):
+        old_environ = os.environ.copy()
+        old_pathsep = os.pathsep
+
+        try:
+            os.environ['SHELL'] = 'C:\\Program Files\\tcmd\\TCC.EXE'
+            os.pathsep = ';'
+
+            activate = print_env('activate', self.ENVIRONMENT, self.ALIASES)
+            assert activate == textwrap.dedent(
+                '''
+                set ANY_LIST_REALLY=something1;something2;%ANY_LIST_REALLY%
+                set PATH=mypath1;mypath2;%PATH%
+                set SINGLE_VAR=single_value
+                alias my_ls ls -la
+                '''
+            ).lstrip()
+
+            os.environ['PATH'] = 'C:\\bin;mypath1;mypath2;C:\\Users\\me\\bin'
+            os.environ['SINGLE_VAR'] = 'single_value'
+            os.environ['ANY_LIST_REALLY'] = 'something1;something2;'
+            deactivate = print_env('deactivate', self.ENVIRONMENT, self.ALIASES)
+            assert deactivate == textwrap.dedent(
+                '''
+                set ANY_LIST_REALLY=
+                set PATH=C:\\bin;C:\\Users\\me\\bin
+                set SINGLE_VAR=
+                unalias my_ls
+                '''
+            ).lstrip()
+        finally:
+            os.environ.clear()
+            os.environ.update(old_environ)
+            os.pathsep = old_pathsep

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -2,4 +2,4 @@ import os
 
 
 def support_file(filename):
-    return os.path.join(os.path.dirname(__file__), '../support', filename)
+    return os.path.join(os.path.dirname(__file__), '..', 'support', filename)


### PR DESCRIPTION
#### Add support for `jinja2` rendering of `environment.yml` files (if `jinja2` is available).

When using `jinja2`, on top of the usual template capabilities, you have access to the
following variables:

- ``root``: The directory containing ``environment.yml``
- ``os``: Python's ``os`` module.

#### Add support for setting environment variables and aliases in `environment.yml`:

```yaml
name: oracle
dependencies:
  - oracle_instantclient

# List type environment variables will be joined with os.pathsep (':' in unix, ';' in windows).
# These values will be inserted in front of any existing value in the current environment.
# e.g.:
#   current PATH: "/usr/local/bin:/usr/bin"
#   new     PATH: "{{ root }}/bin:/usr/local/bin:/usr/bin"
environment:
  ORACLE_HOME: /usr/local/oracle_instantclient
  PATH:
    - {{ root }}/bin

aliases:
  run_db: bash {{ root }}/bin/run_db.sh
```

#### Notes:

* This PR includes the fix in PR #86 (I needed it to make this work)
* Might invalidate the need for PR #85 , 
