### PR TITLE
Feature/upload feedback

### DIFF
--- a/conda_env/cli/main_upload.py
+++ b/conda_env/cli/main_upload.py
@@ -105,7 +105,8 @@ def execute(args, parser):
     uploader = Uploader(name, args.file, summary=summary, force=args.force, env_data=dict(env.to_dict()))
 
     if uploader.authorized():
-        uploader.upload(args.force)
+        info = uploader.upload(args.force)
+        print("Your environment file has been uploaded to {}".format(info['url']))
     else:
         msg = """You are not authorized to upload a package into Binstar.org
                  Verify that you are logged in Binstar.org with:

--- a/conda_env/cli/main_upload.py
+++ b/conda_env/cli/main_upload.py
@@ -106,7 +106,7 @@ def execute(args, parser):
 
     if uploader.authorized():
         info = uploader.upload(args.force)
-        print("Your environment file has been uploaded to {}".format(info['url']))
+        print("Your environment file has been uploaded to {}".format(info.get('url', 'anaconda.org')))
     else:
         msg = """You are not authorized to upload a package into Binstar.org
                  Verify that you are logged in Binstar.org with:

--- a/conda_env/cli/main_upload.py
+++ b/conda_env/cli/main_upload.py
@@ -44,6 +44,7 @@ def configure_parser(sub_parsers):
     p.add_argument(
         '--summary',
         help='Short summary of the environment',
+        default='Environment file'
     )
     p.add_argument(
         '--force',


### PR DESCRIPTION
# Why

* After uploading we don't know where to find the environment uploaded.
* Summary in anaconda.org is: No summary. It's not clear

# Solution

* Display where the environment file has been uploaded
* Has a default summary: Environment file

It will close #90