### PR TITLE
Move import into try except block

### DIFF
--- a/conda_env/utils/uploader.py
+++ b/conda_env/utils/uploader.py
@@ -3,9 +3,9 @@ from collections import namedtuple
 from .. import exceptions
 try:
     from binstar_client.utils import get_binstar
+    from binstar_client import errors
 except ImportError:
     get_binstar = None
-from binstar_client import errors
 
 
 ENVIRONMENT_TYPE = 'env'


### PR DESCRIPTION
# Why

`binstar_client` should not be a dependency, that is why the import should be inside a `try except` block.
Fixes #87