### PR TITLE
Update yaml_file.py

### DIFF
--- a/conda_env/specs/yaml_file.py
+++ b/conda_env/specs/yaml_file.py
@@ -13,7 +13,7 @@ class YamlFileSpec(object):
         try:
             self._environment = env.from_file(self.filename)
             return True
-        except EnvironmentFileNotFound, e:
+        except EnvironmentFileNotFound as e:
             self.msg = e.message
             return False
 


### PR DESCRIPTION
Some time since this morning Travis CI started breaking on all pull requests, 
and complains about a syntax error on this line.

https://travis-ci.org/conda/conda-docs/jobs/65646539#L356

This file hasn't changed in 18 days, so something else happened today to cause 
this, but this tiny fix will go ahead and move the file away from the deprecated 
syntax anyway.