### PR TITLE
Update Python 2-style exception handling to 'as'

### DIFF
--- a/conda_env/specs/yaml_file.py
+++ b/conda_env/specs/yaml_file.py
@@ -13,7 +13,7 @@ class YamlFileSpec(object):
         try:
             self._environment = env.from_file(self.filename)
             return True
-        except EnvironmentFileNotFound, e:
+        except EnvironmentFileNotFound as e:
             self.msg = e.message
             return False
 


### PR DESCRIPTION
This fixes a syntax error in Python 3. I don't actually understand why I can't trigger it normally, but if I cd into the `specs` directory and import it:

```python
>>> import yaml_file as yf
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/nuneziglesiasj/anaconda/envs/py3/lib/python3.4/site-packages/conda_env/specs/yaml_file.py", line 16
    except EnvironmentFileNotFound, e:
```
