### PR TITLE
Display better error when env already uploaded

### DIFF
--- a/conda_env/exceptions.py
+++ b/conda_env/exceptions.py
@@ -19,7 +19,7 @@ class NoBinstar(CondaEnvRuntimeError):
         super(NoBinstar, self).__init__(msg)
 
 
-class AlreadyExist(CondaEnvException):
+class AlreadyExist(CondaEnvRuntimeError):
     def __init__(self):
         msg = 'The environment path already exists'
         super(AlreadyExist, self).__init__(msg)


### PR DESCRIPTION
Problem: #98 
# Solution:

When trying to upload an environment that has already been uploaded show:
```
(conda-3)➜  tmp  conda env upload conda.io
Uploading environment conda.io to anaconda-server (https://api.anaconda.org)...
Error: The environment path already exists
```