### PR TITLE
upload --force working now

### DIFF
--- a/conda_env/cli/main_upload.py
+++ b/conda_env/cli/main_upload.py
@@ -102,7 +102,7 @@ def execute(args, parser):
                  or you can add a name property to your {} file.""".lstrip().format(args.file)
         raise exceptions.CondaEnvRuntimeError(msg)
 
-    uploader = Uploader(name, args.file, summary=summary, force=args.force, env_data=dict(env.to_dict()))
+    uploader = Uploader(name, args.file, summary=summary, env_data=dict(env.to_dict()))
 
     if uploader.authorized():
         info = uploader.upload(args.force)

--- a/conda_env/utils/uploader.py
+++ b/conda_env/utils/uploader.py
@@ -77,7 +77,7 @@ class Uploader(object):
         :return: True/False
         """
         print("Uploading environment %s to anaconda-server (%s)... " % (self.packagename, self.binstar.domain))
-        if force or self.is_ready(force):
+        if self.is_ready(force):
             return self.binstar.upload(self.username, self.packagename,
                                        self.version, self.basename, open(self.file),
                                        distribution_type=ENVIRONMENT_TYPE, attrs=self.env_data)


### PR DESCRIPTION
### Problem
`conda env upload --force` not working:

```sh
➜  tmp  conda env upload conda.io
Uploading environment conda.io to anaconda-server (https://api.anaconda.org)...
Error: The environment path already exists
➜  tmp  conda env upload conda.io --force
Uploading environment conda.io to anaconda-server (https://api.anaconda.org)...
An unexpected error has occurred, please consider sending the
following traceback to the conda GitHub issue tracker at:

    https://github.com/conda/conda/issues

Include the output of the command 'conda info' in your report.


Traceback (most recent call last):
  File "/Users/mvanetta/miniconda/bin/conda-env", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/Users/mvanetta/code/conda/conda-env/bin/conda-env", line 5, in <module>
    sys.exit(main())
  File "/Users/mvanetta/code/conda/conda-env/conda_env/cli/main.py", line 65, in main
    return args_func(args, parser)
  File "/Users/mvanetta/miniconda/lib/python2.7/site-packages/conda/cli/main.py", line 208, in args_func
    args.func(args, p)
  File "/Users/mvanetta/code/conda/conda-env/conda_env/cli/main_upload.py", line 108, in execute
    info = uploader.upload(args.force)
  File "/Users/mvanetta/code/conda/conda-env/conda_env/utils/uploader.py", line 83, in upload
    distribution_type=ENVIRONMENT_TYPE, attrs=self.env_data)
  File "/Users/mvanetta/miniconda/lib/python2.7/site-packages/binstar_client/__init__.py", line 403, in upload
    self._check_response(res)
  File "/Users/mvanetta/miniconda/lib/python2.7/site-packages/binstar_client/__init__.py", line 160, in _check_response
    raise ErrCls(msg, res.status_code)
binstar_client.errors.Conflict: (u'file environment.yml already exists for package conda.io version 1.0', 409)
➜  tmp
```
This is due https://github.com/conda/conda-env/blob/develop/conda_env/utils/uploader.py#L80 . Since `--force` is activated, `force is True` so, due lazy evaluation, `self.is_ready(force)` does not execute and this will prevent https://github.com/conda/conda-env/blob/develop/conda_env/utils/uploader.py#L120 from being executed.

### Solution

Remove `force` from the evaluation