### PR TITLE
export build numbers is optional

### DIFF
--- a/conda_env/cli/main_export.py
+++ b/conda_env/cli/main_export.py
@@ -42,6 +42,14 @@ def configure_parser(sub_parsers):
         required=False
     )
 
+    p.add_argument(
+        '--no-builds',
+        default=False,
+        action='store_true',
+        required=False,
+        help='Remove build specification from dependencies'
+    )
+
     p.set_defaults(func=execute)
 
 
@@ -64,8 +72,7 @@ def execute(args, parser):
     else:
         name = args.name
     prefix = common.get_prefix(args)
-
-    env = from_environment(name, prefix)
+    env = from_environment(name, prefix, no_builds=args.no_builds)
 
     if args.file is None:
         print(env.to_yaml())

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -31,7 +31,7 @@ def load_from_directory(directory):
 
 # TODO This should lean more on conda instead of divining it from the outside
 # TODO tests!!!
-def from_environment(name, prefix):
+def from_environment(name, prefix, no_builds=False):
     installed = install.linked(prefix)
     conda_pkgs = copy(installed)
     # json=True hides the output, data is added to installed
@@ -39,7 +39,10 @@ def from_environment(name, prefix):
 
     pip_pkgs = sorted(installed - conda_pkgs)
 
-    dependencies = ['='.join(a.rsplit('-', 2)) for a in sorted(conda_pkgs)]
+    if no_builds:
+        dependencies = ['='.join(a.rsplit('-', 2)[0:2]) for a in sorted(conda_pkgs)]
+    else:
+        dependencies = ['='.join(a.rsplit('-', 2)) for a in sorted(conda_pkgs)]
     if len(pip_pkgs) > 0:
         dependencies.append({'pip': ['=='.join(a.rsplit('-', 2)[:2]) for a in pip_pkgs]})
 

--- a/conda_env/specs/yaml_file.py
+++ b/conda_env/specs/yaml_file.py
@@ -14,7 +14,7 @@ class YamlFileSpec(object):
             self._environment = env.from_file(self.filename)
             return True
         except EnvironmentFileNotFound as e:
-            self.msg = e.message
+            self.msg = str(e)
             return False
 
     @property


### PR DESCRIPTION
### Why?
If a package has been built for `win` and `linux` but for some reason, (more common than we think) the builds have different numbers, then the `environment.yaml` file won't be cross platform. On the other hand, we don't always need a specific build for a package, we only want the version number.

### Current situation
In order to have an `environment.yaml` file working in different platforms sometimes we have to edit the file and remove the build information from a specific package.

### Solution
Make exporting build information optional:
```sh
$ conda env export -n root
name: root
dependencies:
- certifi=14.05.14=py27_0
- clyent=0.3.4=py27_0
```
and
```sh
$ conda env export -n root --no-builds
name: root
dependencies:
- certifi=14.05.14
- clyent=0.3.4
```
The difference is the `no-builds` flag. cc @tswicegood @chdoig @tonyfast

<!---
@huboard:{"order":78.75,"milestone_order":104,"custom_state":""}
-->
