### PR TITLE
disable user site packages in conda envs

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -77,6 +77,12 @@ else
     return $?
 fi
 
+if [[ ! -z "${PYTHONUSERSITE+x}" ]]; then
+    export CONDA_PYTHONUSERSITE="$PYTHONUSERSITE"
+fi
+# disable user site-packages
+export PYTHONUSERSITE=0
+
 # Load any of the scripts found $PREFIX/etc/conda/activate.d
 run_scripts "activate"
 

--- a/bin/deactivate
+++ b/bin/deactivate
@@ -63,6 +63,13 @@ else
     return $?
 fi
 
+# restore PYTHONUSERSITE env
+unset PYTHONUSERSITE
+if [[ ! -z "${CONDA_PYTHONUSERSITE+x}" ]]; then
+    export PYTHONUSERSITE="$CONDA_PYTHONUSERSITE"
+fi
+unset CONDA_PYTHONUSERSITE
+
 if [[ -n $BASH_VERSION ]]; then
     hash -r
 elif [[ -n $ZSH_VERSION ]]; then


### PR DESCRIPTION
It's surprising that activating a conda env doesn't disable packages that were installed in the global env with `--user`. This matches the default behavior of virtualenv, of creating an actually isolated env.

It would be preferable if this could be accomplished without reliance on an environment variable, but the detections in site.py seem to be pretty hardcoded to virtualenvs.

I'm not sure what, if anything, should be done for the windows scripts.