### PR TITLE
conda env attach

### DIFF
--- a/conda_env/cli/main.py
+++ b/conda_env/cli/main.py
@@ -28,6 +28,7 @@ environment, please open a bug report at:
     else:
         raise e
 
+from . import main_attach
 from . import main_create
 from . import main_export
 from . import main_list
@@ -48,6 +49,7 @@ def create_parser():
     p = argparse.ArgumentParser()
     sub_parsers = p.add_subparsers()
 
+    main_attach.configure_parser(sub_parsers)
     main_create.configure_parser(sub_parsers)
     main_export.configure_parser(sub_parsers)
     main_list.configure_parser(sub_parsers)

--- a/conda_env/cli/main_attach.py
+++ b/conda_env/cli/main_attach.py
@@ -56,9 +56,9 @@ def configure_parser(sub_parsers):
 def execute(args, parser):
     if args.name is not None:
         prefix = common.get_prefix(args)
-        content = from_environment(args.name, prefix).to_yaml()
+        content = from_environment(args.name, prefix).to_dict()
     else:
-        content = "remote: {}".format(args.remote)
+        content = {'remote': args.remote}
 
     print("Environment {} will be attach into {}".format(args.name, args.notebook))
     nb = Notebook(args.notebook)

--- a/conda_env/cli/main_attach.py
+++ b/conda_env/cli/main_attach.py
@@ -23,10 +23,17 @@ def configure_parser(sub_parsers):
         help=description,
         epilog=example,
     )
-    p.add_argument(
+    group = p.add_mutually_exclusive_group(required=True)
+    group.add_argument(
         '-n', '--name',
         action='store',
-        help='environment definition',
+        help='local environment definition',
+        default=None
+    )
+    group.add_argument(
+        '-r', '--remote',
+        action='store',
+        help='remote environment definition',
         default=None
     )
     p.add_argument(
@@ -46,13 +53,11 @@ def configure_parser(sub_parsers):
 
 
 def execute(args, parser):
-    print(args)
-    if args.name is None:
-        args.name = current_env()
+    if args.name is not None:
         prefix = common.get_prefix(args)
         content = from_environment(args.name, prefix).to_yaml()
     else:
-        content = "name: {}".format(args.name)
+        content = "remote: {}".format(args.remote)
 
     print("Environment {} will be attach into {}".format(args.name, args.notebook))
     nb = Notebook(args.notebook)

--- a/conda_env/cli/main_attach.py
+++ b/conda_env/cli/main_attach.py
@@ -42,7 +42,6 @@ def configure_parser(sub_parsers):
         default=None
     )
     common.add_parser_json(p)
-
     p.set_defaults(func=execute)
 
 
@@ -50,12 +49,14 @@ def execute(args, parser):
     print(args)
     if args.name is None:
         args.name = current_env()
-    prefix = common.get_prefix(args)
-    env = from_environment(args.name, prefix)
+        prefix = common.get_prefix(args)
+        content = from_environment(args.name, prefix).to_yaml()
+    else:
+        content = "name: {}".format(args.name)
 
     print("Environment {} will be attach into {}".format(args.name, args.notebook))
     nb = Notebook(args.notebook)
-    if nb.inject(env, args.force):
+    if nb.inject(content, args.force):
         print("Done.")
     else:
         print("The environment couldn't be attached due:")

--- a/conda_env/cli/main_attach.py
+++ b/conda_env/cli/main_attach.py
@@ -1,6 +1,7 @@
 from argparse import RawDescriptionHelpFormatter
-
+from ..utils.notebooks import current_env
 from conda.cli import common
+
 
 description = """
 Attach a Conda environment into a notebook
@@ -45,9 +46,7 @@ def configure_parser(sub_parsers):
 
 
 def execute(args, parser):
-    # info_dict = {'envs': []}
-    # common.handle_envs_list(info_dict['envs'], not args.json)
-    #
-    # if args.json:
-    #     common.stdout_json(info_dict)
-    print(args)
+    name = args.name
+    if args.name is None:
+        name = current_env()
+    print("Environment {} will be attach into {}".format(current_env()['name'], args.notebook))

--- a/conda_env/cli/main_attach.py
+++ b/conda_env/cli/main_attach.py
@@ -1,0 +1,53 @@
+from argparse import RawDescriptionHelpFormatter
+
+from conda.cli import common
+
+description = """
+Attach a Conda environment into a notebook
+"""
+
+example = """
+examples:
+    conda env attach notebook.ipynb
+    conda env attach -n darth/deathstar notebook.ipynb
+"""
+
+
+def configure_parser(sub_parsers):
+    p = sub_parsers.add_parser(
+        'attach',
+        formatter_class=RawDescriptionHelpFormatter,
+        description=description,
+        help=description,
+        epilog=example,
+    )
+    p.add_argument(
+        '-n', '--name',
+        action='store',
+        help='environment definition',
+        default=None
+    )
+    p.add_argument(
+        '--force',
+        action='store_true',
+        default=False,
+        help='Replace existing environment definition'
+    )
+    p.add_argument(
+        'notebook',
+        help='notebook file',
+        action='store',
+        default=None
+    )
+    common.add_parser_json(p)
+
+    p.set_defaults(func=execute)
+
+
+def execute(args, parser):
+    # info_dict = {'envs': []}
+    # common.handle_envs_list(info_dict['envs'], not args.json)
+    #
+    # if args.json:
+    #     common.stdout_json(info_dict)
+    print(args)

--- a/conda_env/cli/main_attach.py
+++ b/conda_env/cli/main_attach.py
@@ -5,7 +5,8 @@ from ..env import from_environment
 
 
 description = """
-Attach a Conda environment into a notebook
+Embeds information describing your conda environment
+into the notebook metadata
 """
 
 example = """

--- a/conda_env/cli/main_attach.py
+++ b/conda_env/cli/main_attach.py
@@ -10,8 +10,8 @@ Attach a Conda environment into a notebook
 
 example = """
 examples:
-    conda env attach notebook.ipynb
-    conda env attach -n darth/deathstar notebook.ipynb
+    conda env attach -n root notebook.ipynb
+    conda env attach -r user/environment notebook.ipynb
 """
 
 

--- a/conda_env/cli/main_attach.py
+++ b/conda_env/cli/main_attach.py
@@ -1,6 +1,7 @@
 from argparse import RawDescriptionHelpFormatter
-from ..utils.notebooks import current_env
+from ..utils.notebooks import current_env, Notebook
 from conda.cli import common
+from ..env import from_environment
 
 
 description = """
@@ -46,7 +47,16 @@ def configure_parser(sub_parsers):
 
 
 def execute(args, parser):
-    name = args.name
+    print(args)
     if args.name is None:
-        name = current_env()
-    print("Environment {} will be attach into {}".format(current_env()['name'], args.notebook))
+        args.name = current_env()
+    prefix = common.get_prefix(args)
+    env = from_environment(args.name, prefix)
+
+    print("Environment {} will be attach into {}".format(args.name, args.notebook))
+    nb = Notebook(args.notebook)
+    if nb.inject(env, args.force):
+        print("Done.")
+    else:
+        print("The environment couldn't be attached due:")
+        print(nb.msg)

--- a/conda_env/exceptions.py
+++ b/conda_env/exceptions.py
@@ -26,7 +26,7 @@ class AlreadyExist(CondaEnvRuntimeError):
 
 
 class EnvironmentAlreadyInNotebook(CondaEnvRuntimeError):
-    def __init__(self, notebook):
+    def __init__(self, notebook, *args, **kwargs):
         msg = "The notebook {} already has an environment"
         super(EnvironmentAlreadyInNotebook, self).__init__(msg, *args, **kwargs)
 

--- a/conda_env/exceptions.py
+++ b/conda_env/exceptions.py
@@ -55,3 +55,11 @@ class InvalidLoader(Exception):
     def __init__(self, name):
         msg = 'Unable to load installer for {}'.format(name)
         super(InvalidLoader, self).__init__(msg)
+
+
+class IPythonNotInstalled(CondaEnvRuntimeError):
+    def __init__(self):
+        msg = """IPython notebook is not installed. Install it with:
+        conda install ipython-noteboook
+        """
+        super(IPythonNotInstalled, self).__init__(msg)

--- a/conda_env/exceptions.py
+++ b/conda_env/exceptions.py
@@ -25,6 +25,12 @@ class AlreadyExist(CondaEnvRuntimeError):
         super(AlreadyExist, self).__init__(msg)
 
 
+class EnvironmentAlreadyInNotebook(CondaEnvRuntimeError):
+    def __init__(self, notebook):
+        msg = "The notebook {} already has an environment"
+        super(EnvironmentAlreadyInNotebook, self).__init__(msg, *args, **kwargs)
+
+
 class EnvironmentFileDoesNotExist(CondaEnvRuntimeError):
     def __init__(self, handle, *args, **kwargs):
         self.handle = handle

--- a/conda_env/utils/notebooks.py
+++ b/conda_env/utils/notebooks.py
@@ -14,10 +14,8 @@ class Notebook(object):
     def inject(self, content, force=False):
         try:
             return self.store_in_file(content, force)
-        except PermissionError:
-            self.msg = "Please verify permission in {}".format(self.notebook)
-        except FileNotFoundError:
-            self.msg = "{} does not exist".format(self.notebook)
+        except IOError:
+            self.msg = "{} may not exist or you don't have adecuate permissions".format(self.notebook)
         except EnvironmentAlreadyInNotebook:
             self.msg = "There is already an environment in {}. Consider '--force'".\
                 format(self.notebook)

--- a/conda_env/utils/notebooks.py
+++ b/conda_env/utils/notebooks.py
@@ -1,0 +1,12 @@
+from os.path import basename
+import conda.config as config
+from conda.cli import common
+
+
+def current_env():
+    """Retrieves dictionary with current environment's name and prefix"""
+    if config.default_prefix == config.root_dir:
+        name = config.root_env_name
+    else:
+        name = basename(config.default_prefix)
+    return {'name': name, 'prefix': config.default_prefix}

--- a/conda_env/utils/notebooks.py
+++ b/conda_env/utils/notebooks.py
@@ -11,9 +11,9 @@ class Notebook(object):
         self.msg = ""
         self.notebook = notebook
 
-    def inject(self, environment, force=False):
+    def inject(self, content, force=False):
         try:
-            return self._inject(environment, force)
+            return self.store_in_file(content, force)
         except PermissionError:
             self.msg = "Please verify permission in {}".format(self.notebook)
         except FileNotFoundError:
@@ -23,11 +23,11 @@ class Notebook(object):
                 format(self.notebook)
         return False
 
-    def _inject(self, environment, force=False):
+    def store_in_file(self, content, force=False):
         with open(self.notebook) as fb:
             data = json.loads(fb.read())
             if force or 'environment' not in data['metadata']:
-                data['metadata']['environment'] = environment.to_yaml()
+                data['metadata']['environment'] = content
             else:
                 raise EnvironmentAlreadyInNotebook(self.notebook)
 

--- a/conda_env/utils/notebooks.py
+++ b/conda_env/utils/notebooks.py
@@ -1,6 +1,39 @@
+import json
 from os.path import basename
 import conda.config as config
 from conda.cli import common
+from ..exceptions import EnvironmentAlreadyInNotebook
+
+
+class Notebook(object):
+    """Inject environment into a notebook"""
+    def __init__(self, notebook):
+        self.msg = ""
+        self.notebook = notebook
+
+    def inject(self, environment, force=False):
+        try:
+            return self._inject(environment, force)
+        except PermissionError:
+            self.msg = "Please verify permission in {}".format(self.notebook)
+        except FileNotFoundError:
+            self.msg = "{} does not exist".format(self.notebook)
+        except EnvironmentAlreadyInNotebook:
+            self.msg = "There is already an environment in {}. Consider '--force'".\
+                format(self.notebook)
+        return False
+
+    def _inject(self, environment, force=False):
+        with open(self.notebook) as fb:
+            data = json.loads(fb.read())
+            if force or 'environment' not in data['metadata']:
+                data['metadata']['environment'] = environment.to_yaml()
+            else:
+                raise EnvironmentAlreadyInNotebook(self.notebook)
+
+        with open(self.notebook, 'w') as fb:
+            fb.write(json.dumps(data))
+        return True
 
 
 def current_env():
@@ -9,4 +42,4 @@ def current_env():
         name = config.root_env_name
     else:
         name = basename(config.default_prefix)
-    return {'name': name, 'prefix': config.default_prefix}
+    return name

--- a/tests/support/notebook-with-env.ipynb
+++ b/tests/support/notebook-with-env.ipynb
@@ -1,0 +1,1 @@
+{"cells": [], "metadata": {"environment": ""}}

--- a/tests/support/notebook.ipynb
+++ b/tests/support/notebook.ipynb
@@ -1,1 +1,1 @@
-{"metadata": {"signature": "", "name": ""}, "nbformat": 3, "nbformat_minor": 0, "worksheets": [{"cells": []}]}
+{"metadata": {"signature": "", "name": ""}, "worksheets": [{"cells": []}], "nbformat_minor": 0, "nbformat": 3}

--- a/tests/support/notebook.ipynb
+++ b/tests/support/notebook.ipynb
@@ -1,1 +1,1 @@
-{"cells": [], "metadata": {}}
+{"metadata": {"signature": "", "name": ""}, "nbformat": 3, "nbformat_minor": 0, "worksheets": [{"cells": []}]}

--- a/tests/support/notebook.ipynb
+++ b/tests/support/notebook.ipynb
@@ -1,0 +1,1 @@
+{"cells": [], "metadata": {}}

--- a/tests/utils/test_notebooks.py
+++ b/tests/utils/test_notebooks.py
@@ -19,7 +19,7 @@ class NotebookTestCase(unittest.TestCase):
     def test_notebook_not_exist(self):
         nb = Notebook('no-exist.ipynb')
         self.assertEqual(nb.inject('content'), False)
-        self.assertEqual(nb.msg, "no-exist.ipynb does not exist")
+        self.assertEqual(nb.msg, "no-exist.ipynb may not exist or you don't have adecuate permissions")
 
     def test_environment_already_exist(self):
         nb = Notebook(support_file('notebook-with-env.ipynb'))

--- a/tests/utils/test_notebooks.py
+++ b/tests/utils/test_notebooks.py
@@ -17,22 +17,24 @@ notebook = {
 
 class NotebookTestCase(unittest.TestCase):
     def test_notebook_not_exist(self):
-        to_yaml = mock.MagicMock(return_value='')
-        env = mock.MagicMock(to_yaml=to_yaml)
         nb = Notebook('no-exist.ipynb')
-        self.assertEqual(nb.inject(env), False)
+        self.assertEqual(nb.inject('content'), False)
         self.assertEqual(nb.msg, "no-exist.ipynb does not exist")
 
     def test_environment_already_exist(self):
-        env = mock.MagicMock()
         nb = Notebook(support_file('notebook-with-env.ipynb'))
-        self.assertEqual(nb.inject(env), False)
+        self.assertEqual(nb.inject('content'), False)
+
+    def test_inject_env(self):
+        nb = Notebook(support_file('notebook.ipynb'))
+        self.assertTrue(nb.inject('content'))
+
+        with open(support_file('notebook.ipynb'), 'w') as fb:
+            fb.write(json.dumps(notebook))
 
     def test_inject(self):
-        to_yaml = mock.MagicMock(return_value='')
-        env = mock.MagicMock(to_yaml=to_yaml)
         nb = Notebook(support_file('notebook.ipynb'))
-        self.assertTrue(nb.inject(env))
+        self.assertTrue(nb.inject('user/environment'))
 
         with open(support_file('notebook.ipynb'), 'w') as fb:
             fb.write(json.dumps(notebook))

--- a/tests/utils/test_notebooks.py
+++ b/tests/utils/test_notebooks.py
@@ -8,10 +8,18 @@ except ImportError:
 from conda_env.utils.notebooks import Notebook
 from ..utils import support_file
 
-
 notebook = {
-    'cells': [],
-    'metadata': {}
+    "metadata": {
+        "name": "",
+        "signature": ""
+    },
+    "nbformat": 3,
+    "nbformat_minor": 0,
+    "worksheets": [
+        {
+            "cells": []
+        }
+    ]
 }
 
 

--- a/tests/utils/test_notebooks.py
+++ b/tests/utils/test_notebooks.py
@@ -1,0 +1,38 @@
+import json
+import unittest
+import tempfile
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+from conda_env.utils.notebooks import Notebook
+from ..utils import support_file
+
+
+notebook = {
+    'cells': [],
+    'metadata': {}
+}
+
+
+class NotebookTestCase(unittest.TestCase):
+    def test_notebook_not_exist(self):
+        to_yaml = mock.MagicMock(return_value='')
+        env = mock.MagicMock(to_yaml=to_yaml)
+        nb = Notebook('no-exist.ipynb')
+        self.assertEqual(nb.inject(env), False)
+        self.assertEqual(nb.msg, "no-exist.ipynb does not exist")
+
+    def test_environment_already_exist(self):
+        env = mock.MagicMock()
+        nb = Notebook(support_file('notebook-with-env.ipynb'))
+        self.assertEqual(nb.inject(env), False)
+
+    def test_inject(self):
+        to_yaml = mock.MagicMock(return_value='')
+        env = mock.MagicMock(to_yaml=to_yaml)
+        nb = Notebook(support_file('notebook.ipynb'))
+        self.assertTrue(nb.inject(env))
+
+        with open(support_file('notebook.ipynb'), 'w') as fb:
+            fb.write(json.dumps(notebook))


### PR DESCRIPTION
#### Problem
Notebooks need an environment to run. If we are going to share notebooks in different platforms, we need a way to share the environment with the notebook.

#### Solution
Attach the current environment into the notebook's metadata. `conda env attach` will grab the curren environment and store it into the notebook's metadata. It will also allow to store remote environments (hosted in anaconda.org) for instance.

```sh
$ conda env attach --help
usage: conda-env attach [-h] (-n NAME | -r REMOTE) [--force] [--json] notebook

Embeds information describing your conda environment
into the notebook metadata

positional arguments:
  notebook              notebook file

optional arguments:
  -h, --help            show this help message and exit
  -n NAME, --name NAME  local environment definition
  -r REMOTE, --remote REMOTE
                        remote environment definition
  --force               Replace existing environment definition
  --json                Report all output as json. Suitable for using conda
                        programmatically.

examples:
    conda env attach -n root notebook.ipynb
    conda env attach -r user/environment notebook.ipynb
```
cc @tonyfast, @chdoig 