### PR TITLE
Double quotes for activate

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -67,7 +67,7 @@ if (( $? == 0 )); then
         export CONDA_DEFAULT_ENV="$@"
     fi
 
-    export CONDA_ENV_PATH=$(get_dirname $_THIS_DIR)
+    export CONDA_ENV_PATH="$(get_dirname $_THIS_DIR)"
 
     if (( $("$_THIS_DIR/conda" ..changeps1) ));  then
             CONDA_OLD_PS1="$PS1"


### PR DESCRIPTION
This PR is hoping to address:
*  [Unable to activate environment in OS with Zsh](https://github.com/conda/conda/issues/1371)

Using the directions found here:
* [When is double quoting necessary?](http://unix.stackexchange.com/questions/68694/when-is-double-quoting-necessary/68748#68748)

This is my first PR against `conda-env`, but please let me know if there is anything I can do to make reviewing this easier or build a better PR.

I am fixing the line that breaks on my local machine. Note that one could get technically use double quotes in every shell variable expansion case in the script. As the article explains, there is no problem in overusing double quotes, and in fact, it's often better to use them always, as a rule of thumb. Happy to do that if it makes sense.