### PR TITLE
conda env export  has no-builds as default

### DIFF
--- a/conda_env/cli/main_attach.py
+++ b/conda_env/cli/main_attach.py
@@ -1,5 +1,5 @@
 from argparse import RawDescriptionHelpFormatter
-from ..utils.notebooks import current_env, Notebook
+from ..utils.notebooks import Notebook
 from conda.cli import common
 from ..env import from_environment
 

--- a/conda_env/cli/main_export.py
+++ b/conda_env/cli/main_export.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, print_function
 from argparse import RawDescriptionHelpFormatter
 import os
-import sys
 import textwrap
 
 from conda.cli import common
@@ -43,11 +42,11 @@ def configure_parser(sub_parsers):
     )
 
     p.add_argument(
-        '--no-builds',
+        '--with-builds',
         default=False,
         action='store_true',
         required=False,
-        help='Remove build specification from dependencies'
+        help='Add build specification from dependencies'
     )
 
     p.set_defaults(func=execute)
@@ -72,7 +71,7 @@ def execute(args, parser):
     else:
         name = args.name
     prefix = common.get_prefix(args)
-    env = from_environment(name, prefix, no_builds=args.no_builds)
+    env = from_environment(name, prefix, with_builds=args.with_builds)
 
     if args.file is None:
         print(env.to_yaml())

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -31,7 +31,7 @@ def load_from_directory(directory):
 
 # TODO This should lean more on conda instead of divining it from the outside
 # TODO tests!!!
-def from_environment(name, prefix, no_builds=False):
+def from_environment(name, prefix, with_builds=False):
     installed = install.linked(prefix)
     conda_pkgs = copy(installed)
     # json=True hides the output, data is added to installed
@@ -39,10 +39,11 @@ def from_environment(name, prefix, no_builds=False):
 
     pip_pkgs = sorted(installed - conda_pkgs)
 
-    if no_builds:
-        dependencies = ['='.join(a.rsplit('-', 2)[0:2]) for a in sorted(conda_pkgs)]
-    else:
+    if with_builds:
         dependencies = ['='.join(a.rsplit('-', 2)) for a in sorted(conda_pkgs)]
+    else:
+        dependencies = ['='.join(a.rsplit('-', 2)[0:2]) for a in sorted(conda_pkgs)]
+
     if len(pip_pkgs) > 0:
         dependencies.append({'pip': ['=='.join(a.rsplit('-', 2)[:2]) for a in pip_pkgs]})
 


### PR DESCRIPTION
* `--no-builds` deprecated
* `--with-bilds` new flag
* `conda env attach` adds environment without builds name