### PR TITLE
Feature/env from notebooks

### DIFF
--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -55,7 +55,7 @@ def configure_parser(sub_parsers):
     )
     p.add_argument(
         'remote_definition',
-        help='remote environment definition',
+        help='remote environment definition / IPython notebook',
         action='store',
         default=None,
         nargs='?'

--- a/conda_env/specs/__init__.py
+++ b/conda_env/specs/__init__.py
@@ -1,10 +1,11 @@
 from .binstar import BinstarSpec
 from .yaml_file import YamlFileSpec
+from .notebook import NotebookSpec
 from ..exceptions import SpecNotFound
-
 
 all_specs = [
     BinstarSpec,
+    NotebookSpec,
     YamlFileSpec
 ]
 

--- a/conda_env/specs/notebook.py
+++ b/conda_env/specs/notebook.py
@@ -1,0 +1,29 @@
+try:
+    from IPython import nbformat
+except ImportError:
+    nbformat = None
+from ..env import Environment
+
+
+class NotebookSpec(object):
+    msg = None
+
+    def __init__(self, name=None, **kwargs):
+        self.name = name
+
+    def can_handle(self):
+        try:
+            self.nb = nbformat.reader.reads(open(self.name).read())
+            return 'environment' in self.nb['metadata']
+        except AttributeError:
+            self.msg = "Please install IPython notebook"
+        except IOError:
+            self.msg = "{} does not exist o can't be accessed".format(self.name)
+        except (nbformat.reader.NotJSONError, KeyError) as e:
+            print(e)
+            self.msg = "{} does not looks like a notebook file".format(self.name)
+        return False
+
+    @property
+    def environment(self):
+        return Environment(**self.nb['metadata']['environment'])

--- a/conda_env/specs/notebook.py
+++ b/conda_env/specs/notebook.py
@@ -3,6 +3,7 @@ try:
 except ImportError:
     nbformat = None
 from ..env import Environment
+from .binstar import BinstarSpec
 
 
 class NotebookSpec(object):
@@ -10,6 +11,7 @@ class NotebookSpec(object):
 
     def __init__(self, name=None, **kwargs):
         self.name = name
+        self.nb = {}
 
     def can_handle(self):
         try:
@@ -26,4 +28,8 @@ class NotebookSpec(object):
 
     @property
     def environment(self):
-        return Environment(**self.nb['metadata']['environment'])
+        if 'remote' in self.nb['metadata']['environment']:
+            spec = BinstarSpec('darth/deathstar')
+            return spec.environment
+        else:
+            return Environment(**self.nb['metadata']['environment'])

--- a/tests/specs/test_notebook.py
+++ b/tests/specs/test_notebook.py
@@ -1,0 +1,19 @@
+import unittest
+from conda_env import env
+from conda_env.specs.notebook import NotebookSpec
+from ..utils import support_file
+
+
+class TestNotebookSpec(unittest.TestCase):
+    def test_no_notebook_file(self):
+        spec = NotebookSpec(support_file('simple.yml'))
+        self.assertEqual(spec.can_handle(), False)
+
+    def test_notebook_no_env(self):
+        spec = NotebookSpec(support_file('notebook.ipynb'))
+        self.assertEqual(spec.can_handle(), False)
+
+    def test_notebook_with_env(self):
+        spec = NotebookSpec(support_file('notebook_with_env.ipynb'))
+        self.assertTrue(spec.can_handle())
+        self.assertIsInstance(spec.environment, env.Environment)

--- a/tests/support/notebook-with-env.ipynb
+++ b/tests/support/notebook-with-env.ipynb
@@ -1,1 +1,0 @@
-{"cells": [], "metadata": {"environment": ""}}

--- a/tests/support/notebook.ipynb
+++ b/tests/support/notebook.ipynb
@@ -1,1 +1,1 @@
-{"metadata": {"signature": "", "name": ""}, "worksheets": [{"cells": []}], "nbformat_minor": 0, "nbformat": 3}
+{"metadata": {"name": "", "signature": ""}, "worksheets": [{"cells": []}], "nbformat_minor": 0, "nbformat": 3}

--- a/tests/support/notebook_with_env.ipynb
+++ b/tests/support/notebook_with_env.ipynb
@@ -1,0 +1,13 @@
+{
+ "cells": [],
+ "metadata": {
+  "environment": {
+   "dependencies": [
+    "ipython-notebook=3.2.0=py27_0"
+   ],
+   "name": "stats"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
# Problem
You can attach an environment into a notebook but you can't do anything with it.

# Solution
Create environment from notebooks with an environment definition stored on it.

# Use
`conda env create notebook.ipynb`