### PR TITLE
Added command 'conda env print' (receives environment.yml file)

### DIFF
--- a/conda_env/cli/main.py
+++ b/conda_env/cli/main.py
@@ -32,9 +32,10 @@ from . import main_attach
 from . import main_create
 from . import main_export
 from . import main_list
+from . import main_print
 from . import main_remove
-from . import main_upload
 from . import main_update
+from . import main_upload
 
 
 # TODO: This belongs in a helper library somewhere
@@ -53,9 +54,10 @@ def create_parser():
     main_create.configure_parser(sub_parsers)
     main_export.configure_parser(sub_parsers)
     main_list.configure_parser(sub_parsers)
+    main_print.configure_parser(sub_parsers)
     main_remove.configure_parser(sub_parsers)
-    main_upload.configure_parser(sub_parsers)
     main_update.configure_parser(sub_parsers)
+    main_upload.configure_parser(sub_parsers)
 
     show_help_on_empty_command()
     return p

--- a/conda_env/cli/main_print.py
+++ b/conda_env/cli/main_print.py
@@ -1,0 +1,48 @@
+from __future__ import print_function
+
+description = """
+Prints content from environment.yml files.
+
+Handles includes and jinja2 parsing.
+"""
+
+example = """
+examples:
+    conda env print path/to/environment.yml
+    conda env print path/to/environment.yml --json
+"""
+
+
+def configure_parser(sub_parsers):
+    from argparse import RawDescriptionHelpFormatter
+
+    p = sub_parsers.add_parser(
+        'print',
+        formatter_class=RawDescriptionHelpFormatter,
+        description=description,
+        help=description,
+        epilog=example,
+    )
+    p.add_argument(
+        '-f', '--file',
+        action='store',
+        help='environment definition file (default: environment.yml)',
+        default='environment.yml',
+    )
+
+    from conda.cli import common
+    common.add_parser_json(p)
+
+    p.set_defaults(func=execute)
+
+
+def execute(args, parser):
+    from conda_env.env import from_file
+    env = from_file(args.file)
+
+    if args.json:
+        from conda.cli.common import stdout_json
+        stdout_json(env.to_dict())
+    else:
+        import sys
+        env.to_yaml(sys.stdout)


### PR DESCRIPTION
Prints content from `environment.yml` files, this also handles `includes`, `jinja2` parsing and any other shenanigans that might be invented for `environment.yml` files.