### PR TITLE
Use conda.cli.conda_argparse.ArgumentParser (enables tab completion!)

### DIFF
--- a/conda_env/cli/main.py
+++ b/conda_env/cli/main.py
@@ -1,5 +1,4 @@
 from __future__ import print_function, division, absolute_import
-import argparse
 import os
 import sys
 
@@ -28,6 +27,8 @@ environment, please open a bug report at:
     else:
         raise e
 
+from conda.cli.conda_argparse import ArgumentParser
+
 from . import main_attach
 from . import main_create
 from . import main_export
@@ -46,7 +47,7 @@ def show_help_on_empty_command():
 
 
 def create_parser():
-    p = argparse.ArgumentParser()
+    p = ArgumentParser()
     sub_parsers = p.add_subparsers()
 
     main_attach.configure_parser(sub_parsers)

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -79,7 +79,7 @@ class Dependencies(OrderedDict):
         self.update({'conda': []})
 
         for line in self.raw:
-            if type(line) is dict:
+            if isinstance(line, dict):
                 self.update(line)
             else:
                 self['conda'].append(common.arg2spec(line))


### PR DESCRIPTION
Use conda.cli.conda_argparse.ArgumentParser. This standardizes on some help string practices, but more importantly, with https://github.com/conda/conda/pull/1443, it enables full tab completion in bash when argcomplete is installed. 