### PR TITLE
Add support for creating envs from requirements.txt files via pip

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -19,8 +19,10 @@ source:
 requirements:
   build:
     - python
+    - pip
   run:
     - python
+    - pip
 
 test:
   commands:

--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -80,6 +80,8 @@ def execute(args, parser):
         # FIXME conda code currently requires args to have a name or prefix
         if args.name is None:
             args.name = env.name
+        else:
+            env.name = args.name
 
     except exceptions.SpecNotFound as e:
         common.error_and_exit(str(e), json=args.json)

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -89,8 +89,12 @@ def get_all_pip_dependencies(requirements_path, temp_dir='_delete_when_done'):
     stdout_data = process.communicate()[0]
     reqs = []
     for line in stdout_data.splitlines():
+        req = ''
         if line.startswith('Collecting'):
             req = line.split(' (', 1)[0][11:]
+        elif line.startswith('Obtaining'):
+            req = line.split(' (', 1)[0][10:]
+        if req:
             if ' from ' in req:
                 req = '-e {}'.format(req.split(' from ', 1)[1])
             reqs.append(req)

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -82,8 +82,9 @@ def get_all_pip_dependencies(requirements_path, temp_dir='_delete_when_done'):
     try:
         os.makedirs(temp_dir)
     except OSError as exc:
-        if exc.errno == errno.EEXIST and isdir(temp_dir):
-            pass
+        # Don't raise exception if directory already exists
+        if not (exc.errno == errno.EEXIST and isdir(temp_dir)):
+            raise
     process = subprocess.Popen(pip_cmd, stdout=subprocess.PIPE,
                                universal_newlines=True)
     stdout_data = process.communicate()[0]

--- a/conda_env/installers/pip.py
+++ b/conda_env/installers/pip.py
@@ -1,10 +1,19 @@
 from __future__ import absolute_import
-import subprocess
 
+import subprocess
+from itertools import chain
+from os.path import join
+
+import conda.config as config
 from conda.cli import main_list
 
 
 def install(prefix, specs, args, env):
-    pip_cmd = main_list.pip_args(prefix) + ['install', ] + specs
+    # This mess is necessary to get --editable package sent to subprocess
+    # properly.
+    specs = list(chain(*[s.split() if '-e' in s else [s] for s in specs]))
+    # Directory where pip will store VCS checkouts for editable packages
+    src_dir = join(config.envs_dirs[0], env.name, 'src')
+    pip_cmd = main_list.pip_args(prefix) + ['install', '--src', src_dir] + specs
     process = subprocess.Popen(pip_cmd, universal_newlines=True)
     process.communicate()

--- a/tests/support/requirements.txt
+++ b/tests/support/requirements.txt
@@ -1,0 +1,4 @@
+# Comment to be ignored
+foo
+ # Comment 2
+baz

--- a/tests/support/requirements.txt
+++ b/tests/support/requirements.txt
@@ -2,4 +2,4 @@
 skll
  # Comment 2
 simplejson
--e https://github.com/fabric/fabric.git#egg=fabric
+-e git+https://github.com/fabric/fabric.git#egg=fabric

--- a/tests/support/requirements.txt
+++ b/tests/support/requirements.txt
@@ -2,3 +2,4 @@
 foo
  # Comment 2
 baz
+numpy

--- a/tests/support/requirements.txt
+++ b/tests/support/requirements.txt
@@ -1,5 +1,5 @@
 # Comment to be ignored
-foo
+skll
  # Comment 2
-baz
-numpy
+simplejson
+-e https://github.com/fabric/fabric.git#egg=fabric

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -43,6 +43,14 @@ class from_file_TestCase(unittest.TestCase):
         self.assert_('foo' in e.dependencies['pip'])
         self.assert_('baz' in e.dependencies['pip'])
 
+    def test_requirements_txt(self):
+        e = env.from_file(utils.support_file('requirements.txt'))
+        self.assert_('foo' in e.dependencies['pip'])
+        self.assert_('baz' in e.dependencies['pip'])
+        self.assert_('# Comment to be ignored' not in e.dependencies['pip'])
+        self.assert_('# Comment 2' not in e.dependencies['pip'])
+        self.assert_(' # Comment 2' not in e.dependencies['pip'])
+
 
 class EnvironmentTestCase(unittest.TestCase):
     def test_has_empty_filename_by_default(self):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -45,8 +45,10 @@ class from_file_TestCase(unittest.TestCase):
 
     def test_requirements_txt(self):
         e = env.from_file(utils.support_file('requirements.txt'))
-        self.assert_('foo' in e.dependencies['pip'])
-        self.assert_('baz' in e.dependencies['pip'])
+        self.assert_('skll' in e.dependencies['pip'])
+        self.assert_('simplejson' in e.dependencies['pip'])
+        self.assert_('-e https://github.com/fabric/fabric.git#egg=fabric' in
+                     e.dependencies['pip'])
         self.assert_('numpy' in e.dependencies['conda'])
         self.assert_('# Comment to be ignored' not in e.dependencies['pip'])
         self.assert_('# Comment 2' not in e.dependencies['pip'])

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -47,6 +47,7 @@ class from_file_TestCase(unittest.TestCase):
         e = env.from_file(utils.support_file('requirements.txt'))
         self.assert_('foo' in e.dependencies['pip'])
         self.assert_('baz' in e.dependencies['pip'])
+        self.assert_('numpy' in e.dependencies)
         self.assert_('# Comment to be ignored' not in e.dependencies['pip'])
         self.assert_('# Comment 2' not in e.dependencies['pip'])
         self.assert_(' # Comment 2' not in e.dependencies['pip'])

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -47,7 +47,7 @@ class from_file_TestCase(unittest.TestCase):
         e = env.from_file(utils.support_file('requirements.txt'))
         self.assert_('foo' in e.dependencies['pip'])
         self.assert_('baz' in e.dependencies['pip'])
-        self.assert_('numpy' in e.dependencies)
+        self.assert_('numpy' in e.dependencies['conda'])
         self.assert_('# Comment to be ignored' not in e.dependencies['pip'])
         self.assert_('# Comment 2' not in e.dependencies['pip'])
         self.assert_(' # Comment 2' not in e.dependencies['pip'])

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -45,9 +45,11 @@ class from_file_TestCase(unittest.TestCase):
 
     def test_requirements_txt(self):
         e = env.from_file(utils.support_file('requirements.txt'))
-        self.assert_('skll' in e.dependencies['pip'])
+        # skll could be in either, depending on active channels
+        self.assert_('skll' in e.dependencies['pip'] or
+                     'skll' in e.dependencies['conda'])
         self.assert_('simplejson' in e.dependencies['pip'])
-        self.assert_('-e https://github.com/fabric/fabric.git#egg=fabric' in
+        self.assert_('-e git+https://github.com/fabric/fabric.git#egg=fabric' in
                      e.dependencies['pip'])
         self.assert_('numpy' in e.dependencies['conda'])
         self.assert_('# Comment to be ignored' not in e.dependencies['pip'])


### PR DESCRIPTION
I found myself frequently wishing this existed, so I added it.

It will use conda packages if available, and fallback to pip otherwise.

There was a bit of nonsense necessary to get editable packages working
properly, but it all works.
