### PR TITLE
allow activation of root win env with no arg

### DIFF
--- a/bin/activate.bat
+++ b/bin/activate.bat
@@ -11,14 +11,7 @@ if "%~2" == "" goto skiptoomanyargs
     goto usage
 :skiptoomanyargs
 
-if not "%CONDA_NEW_NAME%" == "" goto skipmissingarg
-:usage
-    echo Usage: activate envname
-    echo.
-    echo Deactivates previously activated Conda
-    echo environment, then activates the chosen one.
-    exit /b 1
-:skipmissingarg
+if "%CONDA_NEW_NAME%" == "" set CONDA_NEW_NAME=%~dp0..\
 
 if exist "%ANACONDA_ENVS%\%CONDA_NEW_NAME%\conda-meta" goto usenamedenv
     for /F %%i in ("%CONDA_NEW_NAME%") do set CONDA_NEW_PATH=%%~fi
@@ -57,7 +50,11 @@ if "%CONDA_DEFAULT_ENV%" == "" goto skipdeactivate
 set CONDA_DEFAULT_ENV=%CONDA_NEW_PATH%
 echo Activating environment "%CONDA_DEFAULT_ENV%"...
 set PATH="%CONDA_DEFAULT_ENV%";"%CONDA_DEFAULT_ENV%\Scripts";"%CONDA_DEFAULT_ENV%\Library\bin";%PATH%
-set PROMPT=[%CONDA_NEW_NAME%] $P$G
+IF "%CONDA_NEW_NAME%"=="" (
+   set PROMPT=$P$G
+   ) ELSE (
+   set PROMPT=[%CONDA_NEW_NAME%] $P$G
+)
 set CONDA_NEW_NAME=
 set CONDA_NEW_PATH=
 

--- a/bin/activate.bat
+++ b/bin/activate.bat
@@ -52,6 +52,8 @@ echo Activating environment "%CONDA_DEFAULT_ENV%"...
 set PATH="%CONDA_DEFAULT_ENV%";"%CONDA_DEFAULT_ENV%\Scripts";"%CONDA_DEFAULT_ENV%\Library\bin";%PATH%
 IF "%CONDA_NEW_NAME%"=="" (
    set PROMPT=$P$G
+   REM Clear CONDA_DEFAULT_ENV so that this is truly a "root" environment, not an environment pointed at root
+   set CONDA_DEFAULT_ENV=
    ) ELSE (
    set PROMPT=[%CONDA_NEW_NAME%] $P$G
 )


### PR DESCRIPTION
Rather than failing when no argument is passed to activate.bat, this now activates the root environment instead.  This allows us to create shortcuts to starting prompts in the root environment without setting PATH so that activate.bat is locatable in the first place.

This is part of a 4-part addition providing per-environment shortcuts on Windows.

conda/conda#1699
https://github.com/ContinuumIO/menuinst/pull/4
conda/conda-recipes#439