### PR TITLE
rewrite activate.bat and deactivate.bat on win

### DIFF
--- a/bin/deactivate.bat
+++ b/bin/deactivate.bat
@@ -1,36 +1,3 @@
 @echo off
 
-for /f "delims=" %%i in ("%~dp0..\envs") do (
-    set ANACONDA_ENVS=%%~fi
-)
-
-if "%1" == "" goto skipmissingarg
-    echo Usage: deactivate
-    echo.
-    echo Deactivates previously activated Conda
-    echo environment.
-    exit /b 1
-:skipmissingarg
-
-
-REM Deactivate a previous activation if it is live
-if "%CONDA_DEFAULT_ENV%" == "" goto skipdeactivate
-    REM This search/replace removes the previous env from the path
-    echo Deactivating environment "%CONDA_DEFAULT_ENV%"...
-
-    REM Run any deactivate scripts
-    if not exist "%CONDA_DEFAULT_ENV%\etc\conda\deactivate.d" goto nodeactivate
-        pushd "%CONDA_DEFAULT_ENV%\etc\conda\deactivate.d"
-        for %%g in (*.bat) do call "%%g"
-        popd
-    :nodeactivate
-
-    set CONDACTIVATE_PATH="%CONDA_DEFAULT_ENV%";"%CONDA_DEFAULT_ENV%\Scripts";"%CONDA_DEFAULT_ENV%\Library\bin";
-    call set PATH=%%PATH:%CONDACTIVATE_PATH%=%%
-    set CONDA_DEFAULT_ENV=
-    set CONDA_ENV_PATH=
-    set CONDACTIVATE_PATH=
-:skipdeactivate
-
-set PROMPT=%CONDA_OLD_PROMPT%
-set CONDA_OLD_PROMPT=
+call %~dp0\activate.bat DEACTIVATE


### PR DESCRIPTION
This is the same script in spirit, but not in body.  I have rewritten it to use subroutines instead of gotos quite as much (subtle difference, but a big one.)

@ukoethe @ccordoba12 @groutr @wulmer @remram44 @malev , as people who have contributed towards this script in the past or are otherwise involved, please review and ensure that it maintains your functionality.  It would have been nicer to integrate the @wulmer PR: https://github.com/conda/conda-env/pull/182, but I don't want to have to change conda right now, as is required therein.  That will be in the next release.

I have tested this interactively only.  I am writing python-driven tests for this now, but anticipate that this will take me some time to figure out.  I don't know yet how to test what environment I'm on, and I need to work out the subprocess calls and output parsing.

I expect that this PR will not be merged without automated tests in tow, but I would appreciate any comments you have before then.