### PR TITLE
`--quiet` arg action should store `True`

### DIFF
--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -50,7 +50,7 @@ def configure_parser(sub_parsers):
     )
     p.add_argument(
         '-q', '--quiet',
-        action='store_false',
+        action='store_true',
         default=False,
     )
     p.add_argument(

--- a/conda_env/cli/main_update.py
+++ b/conda_env/cli/main_update.py
@@ -48,6 +48,7 @@ def configure_parser(sub_parsers):
     )
     p.add_argument(
         '-q', '--quiet',
+        action='store_true',
         default=False,
     )
     p.add_argument(

--- a/conda_env/cli/main_upload.py
+++ b/conda_env/cli/main_upload.py
@@ -48,7 +48,7 @@ def configure_parser(sub_parsers):
     p.add_argument(
         '-q', '--quiet',
         default=False,
-        action='store_false'
+        action='store_true'
     )
     p.add_argument(
         'name',


### PR DESCRIPTION
The `--quiet` argument doesn't seem to work. I think it should store `True` as it defaults to `False`.