### PR TITLE
Activate keep script dir on PATH

### DIFF
--- a/bin/activate.bat
+++ b/bin/activate.bat
@@ -68,8 +68,6 @@ IF "%CONDA_DEFAULT_ENV%" == "" GOTO skipdeactivate
 
     SET "CONDACTIVATE_PATH=%CONDA_DEFAULT_ENV%;%CONDA_DEFAULT_ENV%\Scripts;%CONDA_DEFAULT_ENV%\Library\bin"
     CALL SET "PATH=%%PATH:%CONDACTIVATE_PATH%=%%"
-    REM Trim trailing semicolon, if any
-    IF "%PATH:~-1%"==";" SET "PATH=%PATH:~0,-1%"
     SET CONDA_DEFAULT_ENV=
 :skipdeactivate
 
@@ -94,6 +92,12 @@ IF NOT EXIST "%CONDA_DEFAULT_ENV%\etc\conda\activate.d" GOTO noactivate
     FOR %%g IN (*.bat) DO CALL "%%g"
     POPD
 :noactivate
+
+REM Trim trailing semicolon, if any
+IF "%PATH:~-1%"==";" SET "PATH=%PATH:~0,-1%"
+
+REM Clean up any double colons we may have ended up with
+SET "PATH=%PATH:;;=;%"
 
 ENDLOCAL & (
     SET "PATH=%PATH%"

--- a/bin/activate.bat
+++ b/bin/activate.bat
@@ -1,82 +1,100 @@
 @echo off
+SETLOCAL ENABLEDELAYEDEXPANSION
 REM Check for CONDA_ENVS_PATH environment variable
 REM It it doesn't exist, look inside the Anaconda install tree
-if "%CONDA_ENVS_PATH%" == "" (
+IF "%CONDA_ENVS_PATH%" == "" (
     REM turn relative path into absolute path
-    FOR /F %%i IN ("%~dp0..\envs") DO set CONDA_ENVS_PATH=%%~fi
+    CALL :NORMALIZEPATH CONDA_ENVS_PATH "%~dp0..\envs"
 )
 
-set CONDA_NEW_NAME=%~1
+set "CONDA_NEW_NAME=%~1"
 
-if "%~2" == "" goto skiptoomanyargs
-    echo ERROR: Too many arguments provided
-    goto usage
+IF "%~2" == "" GOTO skiptoomanyargs
+    ECHO ERROR: Too many arguments provided
+    GOTO usage
 :skiptoomanyargs
 
-if "%CONDA_NEW_NAME%" == "" set CONDA_NEW_NAME=%~dp0..\
+IF "%CONDA_NEW_NAME%" == "" set "CONDA_NEW_NAME=%~dp0.."
 
 REM Search through paths in CONDA_ENVS_PATH
 REM First match will be the one used
 
-for %%F in ("%CONDA_ENVS_PATH:;=" "%") do (
-    if exist "%%~F\%CONDA_NEW_NAME%\conda-meta" (
-       set CONDA_NEW_PATH=%%~F\%CONDA_NEW_NAME%
-       goto found_env
+FOR %%F IN ("%CONDA_ENVS_PATH:;=" "%") DO (
+    IF EXIST "%%~F\%CONDA_NEW_NAME%\conda-meta" (
+       SET "CONDA_NEW_PATH=%%~F\%CONDA_NEW_NAME%"
+       GOTO found_env
     )
 )
 
-if exist "%CONDA_NEW_NAME%\conda-meta" (
-    set CONDA_NEW_PATH=%CONDA_NEW_NAME%
-    ) else (
-    echo No environment named "%CONDA_NEW_NAME%" exists in %CONDA_ENVS_PATH%, or is not a valid conda installation directory.
-    set CONDA_NEW_NAME=
-    set CONDA_NEW_PATH=
-    exit /b 1
+IF EXIST "%CONDA_NEW_NAME%\conda-meta" (
+    SET "CONDA_NEW_PATH=%CONDA_NEW_NAME%"
+    ) ELSE (
+    ECHO No environment named "%CONDA_NEW_NAME%" exists in %CONDA_ENVS_PATH%, or is not a valid conda installation directory.
+    EXIT /b 1
 )
 
 :found_env
 
-for /F %%i in ("%CONDA_NEW_PATH%") do set CONDA_NEW_NAME=%%~ni
+REM Set CONDA_NEW_NAME to the last folder name in its path
+FOR /F "tokens=* delims=\" %%i IN ("%CONDA_NEW_PATH%") DO SET "CONDA_NEW_NAME=%%~ni"
+
+REM special case for root env:
+REM   Checks for Library\bin on PATH.  If exists, we have root env on PATH.
+call :NORMALIZEPATH ROOT_PATH "%~dp0.."
+CALL SET "PATH_NO_ROOT=%%PATH:%ROOT_PATH%;=%%"
+IF NOT "%PATH_NO_ROOT%"=="%PATH%" SET "CONDA_DEFAULT_ENV=%ROOT_PATH%"
 
 REM Deactivate a previous activation if it is live
-if "%CONDA_DEFAULT_ENV%" == "" goto skipdeactivate
+IF "%CONDA_DEFAULT_ENV%" == "" GOTO skipdeactivate
     REM This search/replace removes the previous env from the path
-    echo Deactivating environment "%CONDA_DEFAULT_ENV%"...
+    ECHO Deactivating environment "%CONDA_DEFAULT_ENV%"...
 
     REM Run any deactivate scripts
-    if not exist "%CONDA_DEFAULT_ENV%\etc\conda\deactivate.d" goto nodeactivate
-        pushd "%CONDA_DEFAULT_ENV%\etc\conda\deactivate.d"
-        for %%g in (*.bat) do call "%%g"
-        popd
+    IF NOT EXIST "%CONDA_DEFAULT_ENV%\etc\conda\deactivate.d" GOTO nodeactivate
+        PUSHD "%CONDA_DEFAULT_ENV%\etc\conda\deactivate.d"
+        FOR %%g IN (*.bat) DO CALL "%%g"
+        POPD
     :nodeactivate
 
-    set CONDACTIVATE_PATH=%CONDA_DEFAULT_ENV%;%CONDA_DEFAULT_ENV%\Scripts;%CONDA_DEFAULT_ENV%\Library\bin;
-    call set PATH=%%PATH:%CONDACTIVATE_PATH%=%%
-
     REM Remove env name from PROMPT
-    for /F %%i in ("%CONDA_DEFAULT_ENV%") do set CONDA_OLD_ENV_NAME=%%~ni
+    FOR /F "tokens=* delims=\" %%i IN ("%CONDA_DEFAULT_ENV%") DO SET "CONDA_OLD_ENV_NAME=%%~ni"
     call set PROMPT=%%PROMPT:[%CONDA_OLD_ENV_NAME%] =%%
-    set CONDA_OLD_ENV_NAME=
 
-    set CONDA_DEFAULT_ENV=
-    set CONDACTIVATE_PATH=
+    SET "CONDACTIVATE_PATH=%CONDA_DEFAULT_ENV%;%CONDA_DEFAULT_ENV%\Scripts;%CONDA_DEFAULT_ENV%\Library\bin;"
+    CALL SET "PATH=%%PATH:%CONDACTIVATE_PATH%=%%"
+    SET CONDA_DEFAULT_ENV=
 :skipdeactivate
 
-set CONDA_DEFAULT_ENV=%CONDA_NEW_PATH%
-echo Activating environment "%CONDA_DEFAULT_ENV%"...
-set PATH=%CONDA_DEFAULT_ENV%;%CONDA_DEFAULT_ENV%\Scripts;%CONDA_DEFAULT_ENV%\Library\bin;%PATH%
+CALL :NORMALIZEPATH CONDA_DEFAULT_ENV "%CONDA_NEW_PATH%"
+
+ECHO Activating environment "%CONDA_DEFAULT_ENV%"...
+SET "PATH=%CONDA_DEFAULT_ENV%;%CONDA_DEFAULT_ENV%\Scripts;%CONDA_DEFAULT_ENV%\Library\bin;%PATH%"
 IF "%CONDA_NEW_NAME%"=="" (
    REM Clear CONDA_DEFAULT_ENV so that this is truly a "root" environment, not an environment pointed at root
-   set CONDA_DEFAULT_ENV=
+   SET CONDA_DEFAULT_ENV=
    ) ELSE (
-   set PROMPT=[%CONDA_NEW_NAME%] %PROMPT%
+   SET "PROMPT=[%CONDA_NEW_NAME%] %PROMPT%"
 )
-set CONDA_NEW_NAME=
-set CONDA_NEW_PATH=
+
+REM Make sure that root's Scripts dir is on PATH, for sake of keeping activate/deactivate available.
+CALL SET "PATH_NO_SCRIPTS=%%PATH:%~dp0;=%%"
+IF "%PATH_NO_SCRIPTS%"=="%PATH%" SET "PATH=%PATH%;%~dp0;"
 
 REM Run any activate scripts
-if not exist "%CONDA_DEFAULT_ENV%\etc\conda\activate.d" goto noactivate
-    pushd "%CONDA_DEFAULT_ENV%\etc\conda\activate.d"
-    for %%g in (*.bat) do call "%%g"
-    popd
+IF NOT EXIST "%CONDA_DEFAULT_ENV%\etc\conda\activate.d" GOTO noactivate
+    PUSHD "%CONDA_DEFAULT_ENV%\etc\conda\activate.d"
+    FOR %%g IN (*.bat) DO CALL "%%g"
+    POPD
 :noactivate
+
+ENDLOCAL & (
+    SET "PATH=%PATH%"
+    SET "PROMPT=%PROMPT%"
+    SET "CONDA_DEFAULT_ENV=%CONDA_DEFAULT_ENV%"
+)
+
+EXIT /B
+
+:NORMALIZEPATH
+    SET "%1=%~dpfn2"
+    EXIT /B

--- a/bin/deactivate.bat
+++ b/bin/deactivate.bat
@@ -1,12 +1,12 @@
 @echo off
 SETLOCAL ENABLEDELAYEDEXPANSION
 
-if "%1" == "" goto skipmissingarg
-    echo Usage: deactivate
-    echo.
-    echo Deactivates previously activated Conda
-    echo environment.
-    exit /b 1
+IF "%1" == "" GOTO skipmissingarg
+    ECHO Usage: deactivate
+    ECHO.
+    ECHO Deactivates previously activated Conda
+    ECHO environment.
+    EXIT /b 1
 :skipmissingarg
 
 REM special case for root env:
@@ -16,15 +16,15 @@ CALL SET "PATH_NO_ROOT=%%PATH:%ROOT_PATH%;=%%"
 IF NOT "%PATH_NO_ROOT%"=="%PATH%" SET "CONDA_DEFAULT_ENV=%ROOT_PATH%"
 
 REM Deactivate a previous activation if it is live
-if "%CONDA_DEFAULT_ENV%" == "" goto skipdeactivate
+IF "%CONDA_DEFAULT_ENV%" == "" GOTO skipdeactivate
     REM This search/replace removes the previous env from the path
-    echo Deactivating environment "%CONDA_DEFAULT_ENV%"...
+    ECHO Deactivating environment "%CONDA_DEFAULT_ENV%"...
 
     REM Run any deactivate scripts
-    if not exist "%CONDA_DEFAULT_ENV%\etc\conda\deactivate.d" goto nodeactivate
-        pushd "%CONDA_DEFAULT_ENV%\etc\conda\deactivate.d"
-        for %%g in (*.bat) do call "%%g"
-        popd
+    IF NOT EXIST "%CONDA_DEFAULT_ENV%\etc\conda\deactivate.d" GOTO nodeactivate
+        PUSHD "%CONDA_DEFAULT_ENV%\etc\conda\deactivate.d"
+        FOR %%g IN (*.bat) DO CALL "%%g"
+        POPD
     :nodeactivate
 
     REM Remove env name from PROMPT

--- a/bin/deactivate.bat
+++ b/bin/deactivate.bat
@@ -1,8 +1,5 @@
 @echo off
-
-for /f "delims=" %%i in ("%~dp0..\envs") do (
-    set ANACONDA_ENVS=%%~fi
-)
+SETLOCAL ENABLEDELAYEDEXPANSION
 
 if "%1" == "" goto skipmissingarg
     echo Usage: deactivate
@@ -12,6 +9,11 @@ if "%1" == "" goto skipmissingarg
     exit /b 1
 :skipmissingarg
 
+REM special case for root env:
+REM   Checks for Library\bin on PATH.  If exists, we have root env on PATH.
+call :NORMALIZEPATH ROOT_PATH "%~dp0.."
+CALL SET "PATH_NO_ROOT=%%PATH:%ROOT_PATH%;=%%"
+IF NOT "%PATH_NO_ROOT%"=="%PATH%" SET "CONDA_DEFAULT_ENV=%ROOT_PATH%"
 
 REM Deactivate a previous activation if it is live
 if "%CONDA_DEFAULT_ENV%" == "" goto skipdeactivate
@@ -25,15 +27,26 @@ if "%CONDA_DEFAULT_ENV%" == "" goto skipdeactivate
         popd
     :nodeactivate
 
-    set CONDACTIVATE_PATH=%CONDA_DEFAULT_ENV%;%CONDA_DEFAULT_ENV%\Scripts;%CONDA_DEFAULT_ENV%\Library\bin;
-    call set PATH=%%PATH:%CONDACTIVATE_PATH%=%%
-
     REM Remove env name from PROMPT
-    for /F %%i in ("%CONDA_DEFAULT_ENV%") do set CONDA_OLD_ENV_NAME=%%~ni
+    FOR /F "tokens=* delims=\" %%i IN ("%CONDA_DEFAULT_ENV%") DO SET "CONDA_OLD_ENV_NAME=%%~ni"
     call set PROMPT=%%PROMPT:[%CONDA_OLD_ENV_NAME%] =%%
-    set CONDA_OLD_ENV_NAME=
 
-    set CONDA_DEFAULT_ENV=
-    set CONDA_ENV_PATH=
-    set CONDACTIVATE_PATH=
+    SET "CONDACTIVATE_PATH=%CONDA_DEFAULT_ENV%;%CONDA_DEFAULT_ENV%\Scripts;%CONDA_DEFAULT_ENV%\Library\bin;"
+    CALL SET "PATH=%%PATH:%CONDACTIVATE_PATH%=%%"
 :skipdeactivate
+
+REM Make sure that root's Scripts dir is on PATH, for sake of keeping activate/deactivate available.
+CALL SET "PATH_NO_SCRIPTS=%%PATH:%~dp0;=%%"
+IF "%PATH_NO_SCRIPTS%"=="%PATH%" SET "PATH=%PATH%;%~dp0;"
+
+ENDLOCAL & (
+    SET "PATH=%PATH%"
+    SET "PROMPT=%PROMPT%"
+    SET CONDA_DEFAULT_ENV=
+)
+
+EXIT /B
+
+:NORMALIZEPATH
+    SET "%1=%~dpfn2"
+    EXIT /B

--- a/bin/deactivate.bat
+++ b/bin/deactivate.bat
@@ -44,6 +44,12 @@ REM Make sure that root's Scripts dir is on PATH, for sake of keeping activate/d
 CALL SET "PATH_NO_SCRIPTS=%%PATH:%SCRIPT_PATH%=%%"
 IF "%PATH_NO_SCRIPTS%"=="%PATH%" SET "PATH=%PATH%;%SCRIPT_PATH%"
 
+REM Trim trailing semicolon, if any
+IF "%PATH:~-1%"==";" SET "PATH=%PATH:~0,-1%"
+
+REM Clean up any double colons we may have ended up with
+SET "PATH=%PATH:;;=;%"
+
 ENDLOCAL & (
     SET "PATH=%PATH%"
     SET "PROMPT=%PROMPT%"


### PR DESCRIPTION
This addresses problems reported by several users about conda breaking after activating an environment, due to loss of activate scripts on PATH.  It does so by appending the root Scripts dir onto PATH during any deactivation.  This should always be at the end of PATH, so it hopefully will not interfere.  This does not require modification of the system or user PATH setting, but it is only persistent in a given terminal session.  

This fix also addresses issues with spaces in user paths and environment names.

Ping @groutr @ccordoba12 