### PR TITLE
feature/preprocessing selectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 docs/build
 MANIFEST
 __pycache__
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/build
 MANIFEST
 __pycache__
 .idea/
+.cache/

--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -67,6 +67,12 @@ def configure_parser(sub_parsers):
         action='store_true',
         default=False,
     )
+    p.add_argument(
+        '--select',
+        action='append',
+        help='additional preprocessing selectors (can be passed multiple times)',
+        metavar="SELECTORS",
+    )
     common.add_parser_json(p)
     p.set_defaults(func=execute)
 
@@ -75,7 +81,7 @@ def execute(args, parser):
     name = args.remote_definition or args.name
     try:
         spec = specs.detect(name=name, filename=args.file,
-                            directory=os.getcwd())
+                            directory=os.getcwd(), selectors=args.select)
         env = spec.environment
 
         # FIXME conda code currently requires args to have a name or prefix

--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -70,7 +70,7 @@ def configure_parser(sub_parsers):
     p.add_argument(
         '--select',
         action='append',
-        help='preprocessing selectors (can be passed multiple times)',
+        help="toggle preprocessing selectors. pass multiple times to toggle multiple selectors. pass 'all' to toggle all selectors",
         metavar="SELECTORS",
     )
     common.add_parser_json(p)

--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -70,7 +70,7 @@ def configure_parser(sub_parsers):
     p.add_argument(
         '--select',
         action='append',
-        help='additional preprocessing selectors (can be passed multiple times)',
+        help='preprocessing selectors (can be passed multiple times)',
         metavar="SELECTORS",
     )
     common.add_parser_json(p)

--- a/conda_env/cli/main_update.py
+++ b/conda_env/cli/main_update.py
@@ -58,6 +58,12 @@ def configure_parser(sub_parsers):
         default=None,
         nargs='?'
     )
+    p.add_argument(
+        '--select',
+        action='append',
+        help='additional preprocessing selectors (can be passed multiple times)',
+        metavar="SELECTORS",
+    )
     common.add_parser_json(p)
     p.set_defaults(func=execute)
 
@@ -67,7 +73,7 @@ def execute(args, parser):
 
     try:
         spec = install_specs.detect(name=name, filename=args.file,
-                                    directory=os.getcwd())
+                                    directory=os.getcwd(), selectors=args.select)
         env = spec.environment
     except exceptions.SpecNotFound as e:
         common.error_and_exit(str(e), json=args.json)

--- a/conda_env/cli/main_update.py
+++ b/conda_env/cli/main_update.py
@@ -61,7 +61,7 @@ def configure_parser(sub_parsers):
     p.add_argument(
         '--select',
         action='append',
-        help='additional preprocessing selectors (can be passed multiple times)',
+        help="toggle preprocessing selectors. pass multiple times to toggle multiple selectors. pass 'all' to toggle all selectors",
         metavar="SELECTORS",
     )
     common.add_parser_json(p)

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -4,7 +4,6 @@ from copy import copy
 import os
 import re
 import sys
-import platform
 
 # TODO This should never have to import from conda.cli
 from conda.cli import common
@@ -80,23 +79,23 @@ def from_file(filename, selectors=None):
 
 
 def ns_cfg(custom_selectors, selectors=None):
-    plat = sys.platform
-    arch = platform.architecture()
+    plat = sys.platform  # see https://docs.python.org/2/library/sys.html#sys.platform
+    is_x64 = sys.maxsize > 2**32  # from https://docs.python.org/2/library/platform.html#cross-platform
     d = dict(
         linux=plat.startswith('linux'),
-        linux32=plat.startswith('linux') and '32' in arch,
-        linux64=plat.startswith('linux') and '64' in arch,
+        linux32=plat.startswith('linux') and not is_x64,
+        linux64=plat.startswith('linux') and is_x64,
         osx=plat.startswith('darwin'),
         win=plat.startswith('win32'),
-        win32=plat.startswith('win32') and '32' in arch,
-        win64=plat.startswith('win32') and '64' in arch,
+        win32=plat.startswith('win32') and not is_x64,
+        win64=plat.startswith('win32') and is_x64,
         unix=plat.startswith(('linux', 'darwin')),
         os=os,
         environ=os.environ,
     )
     if selectors is None:
         selectors = []
-    selector_dict = dict((selector, selector in selectors) for selector in custom_selectors)
+    selector_dict = dict((s, s in selectors) for s in custom_selectors)
     d.update(selector_dict)
     return d
 

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -70,21 +70,7 @@ def from_file(filename, selectors=None):
 
 
 def ns_cfg(selectors=None):
-    plat = sys.platform
-    arch = platform.architecture()
-    d = dict(
-        linux=plat.startswith('linux'),
-        linux32=plat.startswith('linux') and '32' in arch,
-        linux64=plat.startswith('linux') and '64' in arch,
-        osx=plat.startswith('darwin'),
-        win=plat.startswith('win32'),
-        win32=plat.startswith('win32') and '32' in arch,
-        win64=plat.startswith('win32') and '64' in arch,
-        unix=plat.startswith(('linux', 'darwin')),
-        os=os,
-        environ=os.environ,
-    )
-    d.update(os.environ)
+    d = dict()
     if selectors and len(selectors) > 0:
         selector_dict = dict((selector, True) for selector in selectors)
         d.update(selector_dict)

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -90,6 +90,10 @@ def ns_cfg(custom_selectors, selectors=None):
         win32=plat.startswith('win32') and not is_x64,
         win64=plat.startswith('win32') and is_x64,
         unix=plat.startswith(('linux', 'darwin')),
+        unix32=plat.startswith(('linux', 'darwin')) and not is_x64,
+        unix64=plat.startswith(('linux', 'darwin')) and is_x64,
+        x86=not is_x64,
+        x64=is_x64,
         os=os,
         environ=os.environ,
     )

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -4,7 +4,6 @@ from copy import copy
 import os
 import re
 import sys
-import platform
 
 # TODO This should never have to import from conda.cli
 from conda.cli import common

--- a/conda_env/specs/yaml_file.py
+++ b/conda_env/specs/yaml_file.py
@@ -5,13 +5,14 @@ from ..exceptions import EnvironmentFileNotFound
 class YamlFileSpec(object):
     _environment = None
 
-    def __init__(self, filename=None, **kwargs):
+    def __init__(self, filename=None, selectors=None, **kwargs):
         self.filename = filename
+        self.selectors = selectors
         self.msg = None
 
     def can_handle(self):
         try:
-            self._environment = env.from_file(self.filename)
+            self._environment = env.from_file(self.filename, self.selectors)
             return True
         except EnvironmentFileNotFound as e:
             self.msg = str(e)

--- a/tests/specs/test_yaml_file.py
+++ b/tests/specs/test_yaml_file.py
@@ -27,7 +27,8 @@ class TestYAMLFile(unittest.TestCase):
 
     def test_filename(self):
         filename = "filename_{}".format(random.randint(100, 200))
+        selectors = None
         with mock.patch.object(env, 'from_file') as from_file:
             spec = YamlFileSpec(filename=filename)
             spec.environment
-        from_file.assert_called_with(filename)
+        from_file.assert_called_with(filename, selectors)

--- a/tests/support/notebook.ipynb
+++ b/tests/support/notebook.ipynb
@@ -1,1 +1,1 @@
-{"metadata": {"signature": "", "name": ""}, "nbformat_minor": 0, "worksheets": [{"cells": []}], "nbformat": 3}
+{"worksheets": [{"cells": []}], "nbformat_minor": 0, "metadata": {"signature": "", "name": ""}, "nbformat": 3}

--- a/tests/support/notebook.ipynb
+++ b/tests/support/notebook.ipynb
@@ -1,1 +1,1 @@
-{"worksheets": [{"cells": []}], "nbformat_minor": 0, "metadata": {"signature": "", "name": ""}, "nbformat": 3}
+{"metadata": {"signature": "", "name": ""}, "nbformat_minor": 0, "worksheets": [{"cells": []}], "nbformat": 3}

--- a/tests/support/selectors.yml
+++ b/tests/support/selectors.yml
@@ -1,4 +1,7 @@
 name: selectors
+selectors:
+  - test
+  - docs
 dependencies:
   - python
   - pytest  # [test]

--- a/tests/support/selectors.yml
+++ b/tests/support/selectors.yml
@@ -7,3 +7,8 @@ dependencies:
   - pytest  # [test]
   - sphinx  # [docs]
   - doctest  # [test and docs]
+  - pywin32  # [win]
+  - foo  # [osx]
+  - bar  # [linux]
+  - baz  # [x64]
+  - quux  # [x86]

--- a/tests/support/selectors.yml
+++ b/tests/support/selectors.yml
@@ -1,0 +1,6 @@
+name: selectors
+dependencies:
+  - python
+  - pytest  # [test]
+  - sphinx  # [docs]
+  - doctest  # [test and docs]

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -81,7 +81,7 @@ class from_file_TestCase(unittest.TestCase):
         self.assert_('sphinx' in e.dependencies['conda'])
         self.assert_('doctest' in e.dependencies['conda'])
     
-     def test_with_selectors_platform(self):
+    def test_with_selectors_platform(self):
         e = env.from_file(utils.support_file('selectors.yml'))
         self.assert_('conda' in e.dependencies)
         if sys.platform.startswith('win32'):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 import os
+import sys
 import random
 import textwrap
 import unittest
@@ -72,12 +73,40 @@ class from_file_TestCase(unittest.TestCase):
         self.assert_('sphinx' in e.dependencies['conda'])
         self.assert_('doctest' in e.dependencies['conda'])
 
+    def test_with_selectors_all(self):
         e = env.from_file(utils.support_file('selectors.yml'), ['all'])
         self.assert_('conda' in e.dependencies)
         self.assert_('python' in e.dependencies['conda'])
         self.assert_('pytest' in e.dependencies['conda'])
         self.assert_('sphinx' in e.dependencies['conda'])
         self.assert_('doctest' in e.dependencies['conda'])
+    
+     def test_with_selectors_platform(self):
+        e = env.from_file(utils.support_file('selectors.yml'))
+        self.assert_('conda' in e.dependencies)
+        if sys.platform.startswith('win32'):
+            self.assert_('pywin32' in e.dependencies['conda'])
+            self.assert_('foo' not in e.dependencies['conda'])
+            self.assert_('bar' not in e.dependencies['conda'])
+        elif sys.platform.startswith('darwin'):
+            self.assert_('pywin32' not in e.dependencies['conda'])
+            self.assert_('foo' in e.dependencies['conda'])
+            self.assert_('bar' not in e.dependencies['conda'])
+        elif sys.platform.startswith('linux'):
+            self.assert_('pywin32' not in e.dependencies['conda'])
+            self.assert_('foo' not in e.dependencies['conda'])
+            self.assert_('bar' in e.dependencies['conda'])
+            
+    def test_with_selectors_architecture(self):
+        e = env.from_file(utils.support_file('selectors.yml'))
+        is_x64 = sys.maxsize > 2**32  # from https://docs.python.org/2/library/platform.html#cross-platform
+        self.assert_('conda' in e.dependencies)
+        if is_x64:
+            self.assert_('baz' in e.dependencies['conda'])
+            self.assert_('quux' not in e.dependencies['conda'])
+        else:
+            self.assert_('baz' not in e.dependencies['conda'])
+            self.assert_('quux' in e.dependencies['conda'])
 
 
 class EnvironmentTestCase(unittest.TestCase):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -43,6 +43,42 @@ class from_file_TestCase(unittest.TestCase):
         self.assert_('foo' in e.dependencies['pip'])
         self.assert_('baz' in e.dependencies['pip'])
 
+    def test_with_selectors(self):
+        e = env.from_file(utils.support_file('selectors.yml'))
+        self.assert_('conda' in e.dependencies)
+        self.assert_('python' in e.dependencies['conda'])
+        self.assert_('pytest' not in e.dependencies['conda'])
+        self.assert_('sphinx' not in e.dependencies['conda'])
+        self.assert_('doctest' not in e.dependencies['conda'])
+
+        e = env.from_file(utils.support_file('selectors.yml'), ['test'])
+        self.assert_('conda' in e.dependencies)
+        self.assert_('python' in e.dependencies['conda'])
+        self.assert_('pytest' in e.dependencies['conda'])
+        self.assert_('sphinx' not in e.dependencies['conda'])
+        self.assert_('doctest' not in e.dependencies['conda'])
+
+        e = env.from_file(utils.support_file('selectors.yml'), ['docs'])
+        self.assert_('conda' in e.dependencies)
+        self.assert_('python' in e.dependencies['conda'])
+        self.assert_('pytest' not in e.dependencies['conda'])
+        self.assert_('sphinx' in e.dependencies['conda'])
+        self.assert_('doctest' not in e.dependencies['conda'])
+
+        e = env.from_file(utils.support_file('selectors.yml'), ['docs', 'test'])
+        self.assert_('conda' in e.dependencies)
+        self.assert_('python' in e.dependencies['conda'])
+        self.assert_('pytest' in e.dependencies['conda'])
+        self.assert_('sphinx' in e.dependencies['conda'])
+        self.assert_('doctest' in e.dependencies['conda'])
+
+        e = env.from_file(utils.support_file('selectors.yml'), ['all'])
+        self.assert_('conda' in e.dependencies)
+        self.assert_('python' in e.dependencies['conda'])
+        self.assert_('pytest' in e.dependencies['conda'])
+        self.assert_('sphinx' in e.dependencies['conda'])
+        self.assert_('doctest' in e.dependencies['conda'])
+
 
 class EnvironmentTestCase(unittest.TestCase):
     def test_has_empty_filename_by_default(self):


### PR DESCRIPTION
This feature allows you to filter dependencies based on preprocessing selectors, similar to [how they work in conda-build](http://conda.pydata.org/docs/building/meta-yaml.html#preprocessing-selectors). You can supply custom selectors to the `create` and `update` commands, like so:

```yaml
name: selectors
selectors:
  - test
  - docs
dependencies:
  - python
  - pytest  # [test]
  - sphinx  # [docs]
  - doctest  # [test and docs]
```

* `conda env create` will install only `python`
* `conda env create --select test` will install `python` and `pytest`
* `conda env create --select test --select docs` will install everything
* `conda env create --select all` will install everything

Unit test included.

This also adds platform selectors, e.g.:

```yaml
name: platforms
dependencies:
  - python
  - pywin32  # [win]
```

The available platform selectors are:

* `linux`
* `linux32`
* `linux64`
* `osx`
* `win`
* `win32`
* `win64`
* `unix` (is equivalent to `osx or linux`)
* `unix32`
* `unix64`
* `x64`
* `x86`

You can specify arbitrary python expressions, since they are `eval`d, and you can use the `os` and `os.environ` (aliased as `environ`) objects as well, e.g.:

```yaml
name: platforms
dependencies:
  - python
  - pywin32  # [win32 and win64]
  - sphinx_rtd_theme  # [not (environ.get('READTHEDOCS', None) == 'True')]
```

Please note that most of the design choices were made so that the functionality mirrors that of [conda-build's preprocessing selectors](http://conda.pydata.org/docs/building/meta-yaml.html#preprocessing-selectors), so that users don't need to become familiar with different syntax.