### PR TITLE
allow 'root' as argument to activate.bat

### DIFF
--- a/bin/activate.bat
+++ b/bin/activate.bat
@@ -18,6 +18,7 @@ IF "%~2" == "" GOTO skiptoomanyargs
 :skiptoomanyargs
 
 IF "%CONDA_NEW_NAME%" == "" set "CONDA_NEW_NAME=%~dp0.."
+IF "%CONDA_NEW_NAME%" == "root" set "CONDA_NEW_NAME=%~dp0.."
 
 REM Search through paths in CONDA_ENVS_PATH
 REM First match will be the one used


### PR DESCRIPTION
This brings activate.bat on Windows into better conformance with behavior on other OS's.  This does not disable activate.bat with no argument, which also activates the root environment.