### PR TITLE
Check return code when calling pip.

### DIFF
--- a/conda_env/installers/pip.py
+++ b/conda_env/installers/pip.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import subprocess
 
+from conda.cli import common
 from conda.pip import pip_args
 
 
@@ -8,3 +9,6 @@ def install(prefix, specs, args, env):
     pip_cmd = pip_args(prefix) + ['install', ] + specs
     process = subprocess.Popen(pip_cmd, universal_newlines=True)
     process.communicate()
+
+    if process.returncode != 0:
+        common.exception_and_exit(ValueError("pip returned an error."))

--- a/tests/installers/test_pip.py
+++ b/tests/installers/test_pip.py
@@ -1,5 +1,8 @@
 import unittest
-from unittest import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from conda_env.installers import pip
 

--- a/tests/installers/test_pip.py
+++ b/tests/installers/test_pip.py
@@ -1,0 +1,28 @@
+import unittest
+from unittest import mock
+
+from conda_env.installers import pip
+
+
+class PipInstallerTest(unittest.TestCase):
+    def test_straight_install(self):
+        with mock.patch.object(pip.subprocess, 'Popen') as popen:
+            popen.return_value.returncode = 0
+            with mock.patch.object(pip, 'pip_args') as pip_args:
+                pip_args.return_value = ['pip']
+
+                pip.install('/some/prefix', ['foo'], '', '')
+
+                popen.assert_called_with(['pip', 'install', 'foo'],
+                                         universal_newlines=True)
+                self.assertEqual(1, popen.return_value.communicate.call_count)
+
+    def test_stops_on_exception(self):
+        with mock.patch.object(pip.subprocess, 'Popen') as popen:
+            popen.return_value.returncode = 22
+            with mock.patch.object(pip, 'pip_args') as pip_args:
+                # make sure that installed doesn't bail early
+                pip_args.return_value = ['pip']
+
+                self.assertRaises(SystemExit, pip.install,
+                                  '/some/prefix', ['foo'], '', '')


### PR DESCRIPTION
Closes #223 

This checks pip's return code and fails the install if pip failed. Adds some mocked tests to check this behaviour.