### PR TITLE
Add a mechanism to let an environment disable the default channels

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,11 @@ in your local package cache.
 You can explicitly provide an environment spec file using ``-f`` or ``--file``
 and the name of the file you would like to use.
 
+The default channels can be excluded by adding ``nodefaults`` to the list of
+channels. This is equivalent to passing the ``--override-channels`` option
+to most ``conda`` commands, and is like ``defaults`` in the ``.condarc``
+channel configuration but with the reverse logic.
+
 Environment file example
 -----------------------
 

--- a/conda_env/installers/conda.py
+++ b/conda_env/installers/conda.py
@@ -9,7 +9,10 @@ def install(prefix, specs, args, env, prune=False):
     common.check_specs(prefix, specs, json=args.json)
 
     # TODO: support all various ways this happens
-    index = common.get_index_trap(channel_urls=env.channels)
+    # Including 'nodefaults' in the channels list disables the defaults
+    index = common.get_index_trap(channel_urls=[chan for chan in env.channels
+                                                     if chan != 'nodefaults'],
+                                  prepend='nodefaults' not in env.channels)
     actions = plan.install_actions(prefix, index, specs, prune=prune)
 
     with common.json_progress_bars(json=args.json and not args.quiet):


### PR DESCRIPTION
Presently the `conda env` command has no way to create environments that are isolated from the anaconda default channels. In `conda` itself, this is done via the `--override-channels` option, but adding that option doesn't bundle that with the environment itself. It makes more sense for the creator of the environment to make this choice than the person running the `conda env` command, so it feels more appropriate to add it to the .yaml file.

This adds the ability to disable the default channels when defining an environment .yaml file by adding a `nodefaults` item to the channels list. This is inspired by the `defaults` in `.condarc`, just with the inverse meaning.
