### PR TITLE
Fix unexpected prune parameter in pip installer.

### DIFF
--- a/conda_env/installers/pip.py
+++ b/conda_env/installers/pip.py
@@ -5,7 +5,7 @@ from conda.cli import common
 from conda_env.pip_util import pip_args
 
 
-def install(prefix, specs, args, env):
+def install(prefix, specs, args, env, prune=False):
     pip_cmd = pip_args(prefix) + ['install', ] + specs
     process = subprocess.Popen(pip_cmd, universal_newlines=True)
     process.communicate()


### PR DESCRIPTION
`prune` keyword parameter has been added in e01ba6f3894be107fc0b14f5eb7326b012a51cbd / #190, but only for the regular `conda` installer.

Because it's missing from the `pip` installer, we end up with the following traceback:
```python
Traceback (most recent call last):
  File "/home/travis/miniconda/bin/conda-env", line 6, in <module>
    sys.exit(conda_env.cli.main.main())
  File "/home/travis/miniconda/lib/python2.7/site-packages/conda_env/cli/main.py", line 68, in main
    return args_func(args, parser)
  File "/home/travis/miniconda/lib/python2.7/site-packages/conda/cli/main.py", line 127, in args_func
    args.func(args, p)
  File "/home/travis/miniconda/lib/python2.7/site-packages/conda_env/cli/main_update.py", line 118, in execute
    installer.install(prefix, specs, args, env, prune=args.prune)
TypeError: install() got an unexpected keyword argument 'prune'
```
Source: https://travis-ci.org/kdeldycke/chessboard/jobs/137781307#L481-L490

This PR fix the call to the pip installer.