### PR TITLE
Add flag to skip prepending channel prefixes

### DIFF
--- a/conda_env/cli/main_export.py
+++ b/conda_env/cli/main_export.py
@@ -62,6 +62,14 @@ def configure_parser(sub_parsers):
         help='Remove build specification from dependencies'
     )
 
+    p.add_argument(
+        '--skip-channel-prefix',
+        default=False,
+        action='store_true',
+        required=False,
+        help='Do not include channel names as prefixes to package names.'
+    )
+
     p.set_defaults(func=execute)
 
 
@@ -84,7 +92,8 @@ def execute(args, parser):
     else:
         name = args.name
     prefix = common.get_prefix(args)
-    env = from_environment(name, prefix, no_builds=args.no_builds)
+    env = from_environment(name, prefix, no_builds=args.no_builds,
+                           skip_channel_prefix=args.skip_channel_prefix)
 
     if args.override_channels:
         env.remove_channels()

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -36,8 +36,8 @@ def load_from_directory(directory):
 
 # TODO This should lean more on conda instead of divining it from the outside
 # TODO tests!!!
-def from_environment(name, prefix, no_builds=False):
-    installed = install.linked(prefix)
+def from_environment(name, prefix, no_builds=False, skip_channel_prefix=False):
+    installed = install.linked(prefix, skip_channel_prefix=skip_channel_prefix)
     conda_pkgs = copy(installed)
     # json=True hides the output, data is added to installed
     add_pip_installed(prefix, installed, json=True)


### PR DESCRIPTION
This depends on the changes in https://github.com/conda/conda/pull/3110 and duplicates the conda-env changes there. Closes https://github.com/conda/conda/issues/2800
